### PR TITLE
Increase max mining fee

### DIFF
--- a/frontend/src/components/TradeBox/Forms/OnchainPayout.tsx
+++ b/frontend/src/components/TradeBox/Forms/OnchainPayout.tsx
@@ -35,9 +35,9 @@ export const OnchainPayoutForm = ({
   const { t } = useTranslation();
 
   const minMiningFee = 2;
-  const maxMiningFee = 100;
+  const maxMiningFee = 500;
   const invalidFee = onchain.miningFee < minMiningFee || onchain.miningFee > maxMiningFee;
-  const costPerVByte = 200;
+  const costPerVByte = 280;
 
   const handleMiningFeeChange = (e) => {
     const miningFee = Number(e.target.value);


### PR DESCRIPTION
## What does this PR do?
This PR increases the maximum mining fee allowed for Onchain Payouts.

In current mempool conditions, the suggested mining fee and the 25 blocks target mining fee are both about 100 Sats/vbyte. The limit is now raised to 500 Sats/vbyte.

This PR will also reject onchain payouts if the remaining amount after subtracting mining fees is close to dust limit (<20,000 Sats)

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [ ] If I added new phrases to the user interface, I have ran prettier `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.