### PR TITLE
Add pgp signature to sensitive client - coordinator messages

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -474,7 +474,11 @@ class MakeOrderSerializer(serializers.ModelSerializer):
 
 class UpdateOrderSerializer(serializers.Serializer):
     invoice = serializers.CharField(
-        max_length=2000, allow_null=True, allow_blank=True, default=None
+        max_length=15000,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
+        help_text="Invoice used for payouts. Must be PGP signed with the robot's public key. The expected Armored PGP header is -----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n",
     )
     routing_budget_ppm = serializers.IntegerField(
         default=0,
@@ -485,7 +489,11 @@ class UpdateOrderSerializer(serializers.Serializer):
         help_text="Max budget to allocate for routing in PPM",
     )
     address = serializers.CharField(
-        max_length=100, allow_null=True, allow_blank=True, default=None
+        max_length=15000,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
+        help_text="Onchain address used for payouts. Must be PGP signed with the robot's public key. The expected Armored PGP header is -----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n",
     )
     statement = serializers.CharField(
         max_length=500_000, allow_null=True, allow_blank=True, default=None

--- a/api/utils.py
+++ b/api/utils.py
@@ -301,6 +301,29 @@ def validate_pgp_keys(pub_key, enc_priv_key):
     return True, None, pub_key, enc_priv_key
 
 
+def verify_signed_message(pub_key, signed_message):
+    """
+    Verifies a signed cleartext PGP message. Returns whether the signature
+    is valid (was made by the given pub_key) and the content of the message.
+    """
+    gpg = gnupg.GPG()
+
+    # import the public key
+    import_result = gpg.import_keys(pub_key)
+
+    # verify the signed message
+    verified = gpg.verify(signed_message)
+
+    if verified.fingerprint == import_result.fingerprints[0]:
+        header = "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA512\n\n"
+        footer = "-----BEGIN PGP SIGNATURE-----"
+        cleartext_message = signed_message.split(header)[1].split(footer)[0].strip()
+
+        return True, cleartext_message
+    else:
+        return False, None
+
+
 def base91_to_hex(base91_str: str) -> str:
     bytes_data = decode(base91_str)
     return bytes_data.hex()

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -3,3 +3,4 @@ static/rest_framework/**
 static/admin/**
 static/frontend/**
 static/import_export/**
+static/drf_spectacular_sidecar/**

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-# Print first start up message when node_modules does not exist
+# Copy node_modules if it doesn't exist
 if [ ! -d "/usr/src/frontend/node_modules" ]; then
     echo "Looks like the first run of this container. Node modules were not detected on the attached volume, copying them into the attached volume."
+    cp -R /tmp/node_modules /usr/src/frontend/node_modules
 fi
-
-# copy modules without replacing
-cp -R -n /tmp/node_modules /usr/src/frontend/node_modules
 
 exec "$@"

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-# Copy node_modules if it doesn't exist
+# Print first start up message when node_modules does not exist
 if [ ! -d "/usr/src/frontend/node_modules" ]; then
     echo "Looks like the first run of this container. Node modules were not detected on the attached volume, copying them into the attached volume."
-    cp -R /tmp/node_modules /usr/src/frontend/node_modules
 fi
+
+# copy modules without replacing
+cp -R -n /tmp/node_modules /usr/src/frontend/node_modules
 
 exec "$@"

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -50,6 +50,7 @@ import { type Order, type Robot, type Settings } from '../../models';
 import { type EncryptedChatMessage } from './EncryptedChat';
 import CollabCancelAlert from './CollabCancelAlert';
 import { Bolt } from '@mui/icons-material';
+import { signCleartextMessage } from '../../pgp';
 
 interface loadingButtonsProps {
   cancel: boolean;
@@ -224,19 +225,23 @@ const TradeBox = ({
 
   const updateInvoice = function (invoice: string) {
     setLoadingButtons({ ...noLoadingButtons, submitInvoice: true });
-    submitAction({
-      action: 'update_invoice',
-      invoice,
-      routing_budget_ppm: lightning.routingBudgetPPM,
+    signCleartextMessage(invoice, robot.encPrivKey, robot.token).then((signedInvoice) => {
+      submitAction({
+        action: 'update_invoice',
+        invoice: signedInvoice,
+        routing_budget_ppm: lightning.routingBudgetPPM,
+      });
     });
   };
 
   const updateAddress = function () {
     setLoadingButtons({ ...noLoadingButtons, submitAddress: true });
-    submitAction({
-      action: 'update_address',
-      address: onchain.address,
-      mining_fee_rate: onchain.miningFee,
+    signCleartextMessage(onchain.address, robot.encPrivKey, robot.token).then((signedAddress) => {
+      submitAction({
+        action: 'update_address',
+        address: signedAddress,
+        mining_fee_rate: onchain.miningFee,
+      });
     });
   };
 

--- a/frontend/src/pgp/index.js
+++ b/frontend/src/pgp/index.js
@@ -6,7 +6,9 @@ import {
   encrypt,
   decrypt,
   createMessage,
+  createCleartextMessage,
   readMessage,
+  sign,
 } from 'openpgp/lightweight';
 import { sha256 } from 'js-sha256';
 
@@ -81,4 +83,20 @@ export async function decryptMessage(
   } catch (e) {
     return { decryptedMessage: decrypted, validSignature: false };
   }
+}
+
+// Sign a cleartext message
+export async function signCleartextMessage(message, privateKeyArmored, passphrase) {
+  const privateKey = await decryptKey({
+    privateKey: await readPrivateKey({ armoredKey: privateKeyArmored }),
+    passphrase,
+  });
+
+  const unsignedMessage = await createCleartextMessage({ text: message });
+  const signedMessage = await sign({
+    message: unsignedMessage,
+    signingKeys: privateKey,
+  });
+
+  return signedMessage;
 }


### PR DESCRIPTION
## What does this PR do?
This is the last pre-requisite for the backend to be fully ready for the Federated model.

Coordinators know the authorization token of a given robot. Therefore, a malicious coordinator, could try to sneak into the orders that a robot has with another coordinator. This is not an issue for chat messages, as these are PGP encrypted, and the coordinator does not know the robot token. However, the coordinator, could be sneaky and try to submit an invoice or address of his own (alla MITM) to be paid out to his account once a trade finishes. 

This PR extends the use of PGP signatures to addresses and invoices. A coordinator will only accept an address or invoice if it has been signed by the key of the robot, hence, proving possession of the robot token.

This PR is compatible with previous clients (they still send unsigned invoices/addresses). The support for unsigned Invoices/addresses will be dropped after v0.5.1

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [ ] If I added new phrases to the user interface, I have ran `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.