### PR TITLE
changes for 0.5 and some small fixes

### DIFF
--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -209,7 +209,7 @@ class CLNNode:
             else:
                 raise e
 
-        return response.state == 1  # True if state is CANCELED, false otherwise.
+        return response.state == 2  # True if state is CANCELED, false otherwise.
 
     @classmethod
     def settle_hold_invoice(cls, preimage):
@@ -225,7 +225,7 @@ class CLNNode:
             else:
                 raise e
 
-        return response.state == 2  # True if state is SETTLED, false otherwise.
+        return response.state == 1  # True if state is SETTLED, false otherwise.
 
     @classmethod
     def gen_hold_invoice(cls, num_satoshis, description, invoice_expiry, cltv_expiry_blocks, order_id, lnpayment_concept, time):

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -221,7 +221,7 @@ class CLNNode:
 
         # constant 100h invoice expiry because cln has to cancel htlcs if invoice expires
         # or it can't associate them anymore
-        invoice_expiry = 360000
+        invoice_expiry = cltv_expiry_blocks * 10 * 60
 
         hold_payment = {}
         # The preimage is a random hash of 256 bits entropy

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -616,7 +616,8 @@ class CLNNode:
                 elif status_code == 207:  # invoice expired
                     print(f"Order: {order.id}. INVOICE EXPIRED. Hash: {hash}")
 
-                    request_listpays = noderpc.ListpaysRequest(payment_hash=hash)
+                    request_listpays = noderpc.ListpaysRequest(
+                        payment_hash=bytes.fromhex(hash))
                     try:
                         response_listpays = cls.stub.ListPays(request_listpays)
                     except Exception as e:

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -514,91 +514,28 @@ class CLNNode:
             print(f"Order: {order.id} Payout is larger than collateral !?")
             return
 
-        def handle_response(response, was_in_transit=False):
-            lnpayment.status = LNPayment.Status.FLIGHT
-            lnpayment.in_flight = True
-            lnpayment.save(update_fields=["in_flight", "status"])
-            order.status = Order.Status.PAY
-            order.save(update_fields=["status"])
+        was_in_transit = False
+        for i in range(3):
+            try:
+                response = cls.stub.Pay(request)
+                lnpayment.status = LNPayment.Status.FLIGHT
+                lnpayment.in_flight = True
+                lnpayment.save(update_fields=["in_flight", "status"])
+                order.status = Order.Status.PAY
+                order.save(update_fields=["status"])
 
-            if response.status == 1:  # Status 1 'PENDING'
-                print(f"Order: {order.id} IN_FLIGHT. Hash {hash}")
+                if response.status == 1:  # Status 1 'PENDING'
+                    print(f"Order: {order.id} IN_FLIGHT. Hash {hash}")
 
-                # If payment was already "payment is in transition" we do not
-                # want to spawn a new thread every 3 minutes to check on it.
-                # in case this thread dies, let's move the last_routing_time
-                # 20 minutes in the future so another thread spawns.
-                if was_in_transit:
-                    lnpayment.last_routing_time = timezone.now() + timedelta(minutes=20)
-                    lnpayment.save(update_fields=["last_routing_time"])
+                    # If payment was already "payment is in transition" we do not
+                    # want to spawn a new thread every 3 minutes to check on it.
+                    # in case this thread dies, let's move the last_routing_time
+                    # 20 minutes in the future so another thread spawns.
+                    if was_in_transit:
+                        lnpayment.last_routing_time = timezone.now() + timedelta(minutes=20)
+                        lnpayment.save(update_fields=["last_routing_time"])
 
-            if response.status == 2:  # Status 3 'FAILED'
-                lnpayment.status = LNPayment.Status.FAILRO
-                lnpayment.last_routing_time = timezone.now()
-                lnpayment.routing_attempts += 1
-                lnpayment.failure_reason = LNPayment.FailureReason.NOROUTE
-                lnpayment.in_flight = False
-                if lnpayment.routing_attempts > 2:
-                    lnpayment.status = LNPayment.Status.EXPIRE
-                    lnpayment.routing_attempts = 0
-                lnpayment.save(
-                    update_fields=[
-                        "status",
-                        "last_routing_time",
-                        "routing_attempts",
-                        "failure_reason",
-                        "in_flight",
-                    ]
-                )
-
-                order.status = Order.Status.FAI
-                order.expires_at = timezone.now() + timedelta(
-                    seconds=order.t_to_expire(Order.Status.FAI)
-                )
-                order.save(update_fields=["status", "expires_at"])
-                print(
-                    f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[-1]}"
-                )
-                return {
-                    "succeded": False,
-                    "context": f"payment failure reason: {cls.payment_failure_context[-1]}",
-                }
-
-            if response.status == 0:  # Status 2 'COMPLETE'
-                print(f"Order: {order.id} SUCCEEDED. Hash: {hash}")
-                lnpayment.status = LNPayment.Status.SUCCED
-                lnpayment.fee = (
-                    float(response.amount_sent_msat.msat - response.amount_msat.msat)
-                    / 1000
-                )
-                lnpayment.preimage = response.payment_preimage.hex()
-                lnpayment.save(update_fields=["status", "fee", "preimage"])
-                order.status = Order.Status.SUC
-                order.expires_at = timezone.now() + timedelta(
-                    seconds=order.t_to_expire(Order.Status.SUC)
-                )
-                order.save(update_fields=["status", "expires_at"])
-
-                results = {"succeded": True}
-                return results
-
-        try:
-            response = cls.stub.Pay(request)
-            handle_response(response)
-
-        except grpc._channel._InactiveRpcError as e:
-            if "code: Some" in str(e):
-                status_code = int(e.details().split("code: Some(")[1].split(")")[0])
-                if (
-                    status_code == 201
-                ):  # Already paid with this hash using different amount or destination
-                    # i don't think this can happen really, since we don't use the amount_msat in request
-                    # and if you just try 'pay' 2x where the first time it succeeds you get the same
-                    # non-error result the 2nd time.
-                    print(f"Order: {order.id} ALREADY PAID. Hash: {hash}.")
-
-                # Permanent failure at destination. or Unable to find a route. or Route too expensive.
-                elif status_code == 203 or status_code == 205 or status_code == 206 or status_code == 210:
+                if response.status == 2:  # Status 3 'FAILED'
                     lnpayment.status = LNPayment.Status.FAILRO
                     lnpayment.last_routing_time = timezone.now()
                     lnpayment.routing_attempts += 1
@@ -609,7 +546,12 @@ class CLNNode:
                         lnpayment.routing_attempts = 0
                     lnpayment.save(
                         update_fields=[
-                            "status", "last_routing_time", "routing_attempts", "in_flight", "failure_reason"]
+                            "status",
+                            "last_routing_time",
+                            "routing_attempts",
+                            "failure_reason",
+                            "in_flight",
+                        ]
                     )
 
                     order.status = Order.Status.FAI
@@ -618,37 +560,114 @@ class CLNNode:
                     )
                     order.save(update_fields=["status", "expires_at"])
                     print(
-                        f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[status_code]}"
+                        f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[-1]}"
                     )
                     return {
                         "succeded": False,
-                        "context": f"payment failure reason: {cls.payment_failure_context[status_code]}",
+                        "context": f"payment failure reason: {cls.payment_failure_context[-1]}",
                     }
-                elif status_code == 207:  # invoice expired
-                    print(f"Order: {order.id}. INVOICE EXPIRED. Hash: {hash}")
 
-                    lnpayment.status = LNPayment.Status.EXPIRE
-                    lnpayment.last_routing_time = timezone.now()
-                    lnpayment.in_flight = False
-                    lnpayment.save(
-                        update_fields=["status", "last_routing_time", "in_flight"])
-                    order.status = Order.Status.FAI
+                if response.status == 0:  # Status 2 'COMPLETE'
+                    print(f"Order: {order.id} SUCCEEDED. Hash: {hash}")
+                    lnpayment.status = LNPayment.Status.SUCCED
+                    lnpayment.fee = (
+                        float(response.amount_sent_msat.msat - response.amount_msat.msat)
+                        / 1000
+                    )
+                    lnpayment.preimage = response.payment_preimage.hex()
+                    lnpayment.save(update_fields=["status", "fee", "preimage"])
+                    order.status = Order.Status.SUC
                     order.expires_at = timezone.now() + timedelta(
-                        seconds=order.t_to_expire(Order.Status.FAI)
+                        seconds=order.t_to_expire(Order.Status.SUC)
                     )
                     order.save(update_fields=["status", "expires_at"])
-                    results = {
-                        "succeded": False,
-                        "context": "The payout invoice has expired",
-                    }
-                    return results
-                else:  # -1 (general error)
-                    print(str(e))
-            else:
-                print(str(e))
 
-        except Exception as e:
-            print(str(e))
+                    results = {"succeded": True}
+                    return results
+
+            except grpc._channel._InactiveRpcError as e:
+                if "code: Some" in str(e):
+                    status_code = int(e.details().split("code: Some(")[1].split(")")[0])
+                    if (
+                        status_code == 201
+                    ):  # Already paid with this hash using different amount or destination
+                        # i don't think this can happen really, since we don't use the amount_msat in request
+                        # and if you just try 'pay' 2x where the first time it succeeds you get the same
+                        # non-error result the 2nd time.
+                        print(
+                            f"Order: {order.id} ALREADY PAID using different amount or destination THIS SHOULD NEVER HAPPEN! Hash: {hash}.")
+
+                    # Permanent failure at destination. or Unable to find a route. or Route too expensive.
+                    elif status_code == 203 or status_code == 205 or status_code == 206 or status_code == 210:
+                        lnpayment.status = LNPayment.Status.FAILRO
+                        lnpayment.last_routing_time = timezone.now()
+                        lnpayment.routing_attempts += 1
+                        lnpayment.failure_reason = LNPayment.FailureReason.NOROUTE
+                        lnpayment.in_flight = False
+                        if lnpayment.routing_attempts > 2:
+                            lnpayment.status = LNPayment.Status.EXPIRE
+                            lnpayment.routing_attempts = 0
+                        lnpayment.save(
+                            update_fields=[
+                                "status", "last_routing_time", "routing_attempts", "in_flight", "failure_reason"]
+                        )
+
+                        order.status = Order.Status.FAI
+                        order.expires_at = timezone.now() + timedelta(
+                            seconds=order.t_to_expire(Order.Status.FAI)
+                        )
+                        order.save(update_fields=["status", "expires_at"])
+                        print(
+                            f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[status_code]}"
+                        )
+                        return {
+                            "succeded": False,
+                            "context": f"payment failure reason: {cls.payment_failure_context[status_code]}",
+                        }
+                    elif status_code == 207:  # invoice expired
+                        print(f"Order: {order.id}. INVOICE EXPIRED. Hash: {hash}")
+
+                        request_listpays = noderpc.ListpaysRequest(payment_hash=hash)
+                        try:
+                            response_listpays = cls.stub.ListPays(request_listpays)
+                        except Exception as e:
+                            print(str(e))
+
+                        if len(response_listpays.pays) == 0:
+                            print(
+                                f"Order: {order.id}. UNUSUAL: Payment for expired invoice not found. Hash: {hash}")
+                            continue
+
+                        still_inflight = False
+                        for pay in response_listpays.pays:
+                            if pay.status == 0:
+                                still_inflight = True
+                            elif pay.status == 2:
+                                print(
+                                    f"Order: {order.id} Payment got accepted after invoice expiry! Hash: {hash}")
+
+                        if still_inflight:
+                            was_in_transit = True
+                        else:
+                            lnpayment.status = LNPayment.Status.EXPIRE
+                            lnpayment.last_routing_time = timezone.now()
+                            lnpayment.in_flight = False
+                            lnpayment.save(
+                                update_fields=["status", "last_routing_time", "in_flight"])
+                            order.status = Order.Status.FAI
+                            order.expires_at = timezone.now() + timedelta(
+                                seconds=order.t_to_expire(Order.Status.FAI)
+                            )
+                            order.save(update_fields=["status", "expires_at"])
+                            results = {
+                                "succeded": False,
+                                "context": "The payout invoice has expired",
+                            }
+                            return results
+                    else:  # -1 (general error)
+                        print(str(e))
+                else:
+                    print(str(e))
 
     @classmethod
     def double_check_htlc_is_settled(cls, payment_hash):

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -535,7 +535,7 @@ class CLNNode:
                         lnpayment.last_routing_time = timezone.now() + timedelta(minutes=20)
                         lnpayment.save(update_fields=["last_routing_time"])
 
-                if response.status == 2:  # Status 3 'FAILED'
+                if response.status == 2:  # Status 2 'FAILED'
                     lnpayment.status = LNPayment.Status.FAILRO
                     lnpayment.last_routing_time = timezone.now()
                     lnpayment.routing_attempts += 1
@@ -567,7 +567,7 @@ class CLNNode:
                         "context": f"payment failure reason: {cls.payment_failure_context[-1]}",
                     }
 
-                if response.status == 0:  # Status 2 'COMPLETE'
+                if response.status == 0:  # Status 0 'COMPLETE'
                     print(f"Order: {order.id} SUCCEEDED. Hash: {hash}")
                     lnpayment.status = LNPayment.Status.SUCCED
                     lnpayment.fee = (

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -201,7 +201,13 @@ class CLNNode:
         request = noderpc.HodlInvoiceCancelRequest(
             payment_hash=bytes.fromhex(payment_hash)
         )
-        response = cls.stub.HodlInvoiceCancel(request)
+        try:
+            response = cls.stub.HodlInvoiceCancel(request)
+        except Exception as e:
+            if "Timed out" in str(e):
+                return True
+            else:
+                raise e
 
         return response.state == 1  # True if state is CANCELED, false otherwise.
 
@@ -211,7 +217,13 @@ class CLNNode:
         request = noderpc.HodlInvoiceSettleRequest(
             payment_hash=hashlib.sha256(bytes.fromhex(preimage)).digest()
         )
-        response = cls.stub.HodlInvoiceSettle(request)
+        try:
+            response = cls.stub.HodlInvoiceSettle(request)
+        except Exception as e:
+            if "Timed out" in str(e):
+                return True
+            else:
+                raise e
 
         return response.state == 2  # True if state is SETTLED, false otherwise.
 

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -505,12 +505,14 @@ class CLNNode:
         was_in_transit = False
         for i in range(3):
             try:
-                response = cls.stub.Pay(request)
                 lnpayment.status = LNPayment.Status.FLIGHT
                 lnpayment.in_flight = True
                 lnpayment.save(update_fields=["in_flight", "status"])
+
                 order.status = Order.Status.PAY
                 order.save(update_fields=["status"])
+
+                response = cls.stub.Pay(request)
 
                 if response.status == 1:  # Status 1 'PENDING'
                     print(f"Order: {order.id} IN_FLIGHT. Hash {hash}")

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -111,10 +111,10 @@ class CLNNode:
         total_balance = 0
         for utxo in response.outputs:
             if not utxo.reserved:
-                if utxo.status == 0:  # UNCONFIRMED
+                if utxo.status == noderpc.ListfundsOutputs.ListfundsOutputsStatus.UNCONFIRMED:
                     unconfirmed_balance += utxo.amount_msat.msat // 1_000
                     total_balance += utxo.amount_msat.msat // 1_000
-                elif utxo.status == 1:  # CONFIRMED
+                elif utxo.status == noderpc.ListfundsOutputs.ListfundsOutputsStatus.CONFIRMED:
                     confirmed_balance += utxo.amount_msat.msat // 1_000
                     total_balance += utxo.amount_msat.msat // 1_000
 

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -503,29 +503,91 @@ class CLNNode:
             return
 
         was_in_transit = False
-        for i in range(3):
-            try:
-                lnpayment.status = LNPayment.Status.FLIGHT
-                lnpayment.in_flight = True
-                lnpayment.save(update_fields=["in_flight", "status"])
+        try:
+            lnpayment.status = LNPayment.Status.FLIGHT
+            lnpayment.in_flight = True
+            lnpayment.save(update_fields=["in_flight", "status"])
 
-                order.status = Order.Status.PAY
-                order.save(update_fields=["status"])
+            order.status = Order.Status.PAY
+            order.save(update_fields=["status"])
 
-                response = cls.stub.Pay(request)
+            response = cls.stub.Pay(request)
 
-                if response.status == 1:  # Status 1 'PENDING'
-                    print(f"Order: {order.id} IN_FLIGHT. Hash {hash}")
+            if response.status == 1:  # Status 1 'PENDING'
+                print(f"Order: {order.id} IN_FLIGHT. Hash {hash}")
 
-                    # If payment was already "payment is in transition" we do not
-                    # want to spawn a new thread every 3 minutes to check on it.
-                    # in case this thread dies, let's move the last_routing_time
-                    # 20 minutes in the future so another thread spawns.
-                    if was_in_transit:
-                        lnpayment.last_routing_time = timezone.now() + timedelta(minutes=20)
-                        lnpayment.save(update_fields=["last_routing_time"])
+                # If payment was already "payment is in transition" we do not
+                # want to spawn a new thread every 3 minutes to check on it.
+                # in case this thread dies, let's move the last_routing_time
+                # 20 minutes in the future so another thread spawns.
+                if was_in_transit:
+                    lnpayment.last_routing_time = timezone.now() + timedelta(minutes=20)
+                    lnpayment.save(update_fields=["last_routing_time"])
 
-                if response.status == 2:  # Status 2 'FAILED'
+            if response.status == 2:  # Status 2 'FAILED'
+                lnpayment.status = LNPayment.Status.FAILRO
+                lnpayment.last_routing_time = timezone.now()
+                lnpayment.routing_attempts += 1
+                lnpayment.failure_reason = LNPayment.FailureReason.NOROUTE
+                lnpayment.in_flight = False
+                if lnpayment.routing_attempts > 2:
+                    lnpayment.status = LNPayment.Status.EXPIRE
+                    lnpayment.routing_attempts = 0
+                lnpayment.save(
+                    update_fields=[
+                        "status",
+                        "last_routing_time",
+                        "routing_attempts",
+                        "failure_reason",
+                        "in_flight",
+                    ]
+                )
+
+                order.status = Order.Status.FAI
+                order.expires_at = timezone.now() + timedelta(
+                    seconds=order.t_to_expire(Order.Status.FAI)
+                )
+                order.save(update_fields=["status", "expires_at"])
+                print(
+                    f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[-1]}"
+                )
+                return {
+                    "succeded": False,
+                    "context": f"payment failure reason: {cls.payment_failure_context[-1]}",
+                }
+
+            if response.status == 0:  # Status 0 'COMPLETE'
+                print(f"Order: {order.id} SUCCEEDED. Hash: {hash}")
+                lnpayment.status = LNPayment.Status.SUCCED
+                lnpayment.fee = (
+                    float(response.amount_sent_msat.msat - response.amount_msat.msat)
+                    / 1000
+                )
+                lnpayment.preimage = response.payment_preimage.hex()
+                lnpayment.save(update_fields=["status", "fee", "preimage"])
+                order.status = Order.Status.SUC
+                order.expires_at = timezone.now() + timedelta(
+                    seconds=order.t_to_expire(Order.Status.SUC)
+                )
+                order.save(update_fields=["status", "expires_at"])
+
+                results = {"succeded": True}
+                return results
+
+        except grpc._channel._InactiveRpcError as e:
+            if "code: Some" in str(e):
+                status_code = int(e.details().split("code: Some(")[1].split(")")[0])
+                if (
+                    status_code == 201
+                ):  # Already paid with this hash using different amount or destination
+                    # i don't think this can happen really, since we don't use the amount_msat in request
+                    # and if you just try 'pay' 2x where the first time it succeeds you get the same
+                    # non-error result the 2nd time.
+                    print(
+                        f"Order: {order.id} ALREADY PAID using different amount or destination THIS SHOULD NEVER HAPPEN! Hash: {hash}.")
+
+                # Permanent failure at destination. or Unable to find a route. or Route too expensive.
+                elif status_code == 203 or status_code == 205 or status_code == 206 or status_code == 210:
                     lnpayment.status = LNPayment.Status.FAILRO
                     lnpayment.last_routing_time = timezone.now()
                     lnpayment.routing_attempts += 1
@@ -536,12 +598,7 @@ class CLNNode:
                         lnpayment.routing_attempts = 0
                     lnpayment.save(
                         update_fields=[
-                            "status",
-                            "last_routing_time",
-                            "routing_attempts",
-                            "failure_reason",
-                            "in_flight",
-                        ]
+                            "status", "last_routing_time", "routing_attempts", "in_flight", "failure_reason"]
                     )
 
                     order.status = Order.Status.FAI
@@ -550,114 +607,58 @@ class CLNNode:
                     )
                     order.save(update_fields=["status", "expires_at"])
                     print(
-                        f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[-1]}"
+                        f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[status_code]}"
                     )
                     return {
                         "succeded": False,
-                        "context": f"payment failure reason: {cls.payment_failure_context[-1]}",
+                        "context": f"payment failure reason: {cls.payment_failure_context[status_code]}",
                     }
+                elif status_code == 207:  # invoice expired
+                    print(f"Order: {order.id}. INVOICE EXPIRED. Hash: {hash}")
 
-                if response.status == 0:  # Status 0 'COMPLETE'
-                    print(f"Order: {order.id} SUCCEEDED. Hash: {hash}")
-                    lnpayment.status = LNPayment.Status.SUCCED
-                    lnpayment.fee = (
-                        float(response.amount_sent_msat.msat - response.amount_msat.msat)
-                        / 1000
-                    )
-                    lnpayment.preimage = response.payment_preimage.hex()
-                    lnpayment.save(update_fields=["status", "fee", "preimage"])
-                    order.status = Order.Status.SUC
-                    order.expires_at = timezone.now() + timedelta(
-                        seconds=order.t_to_expire(Order.Status.SUC)
-                    )
-                    order.save(update_fields=["status", "expires_at"])
+                    request_listpays = noderpc.ListpaysRequest(payment_hash=hash)
+                    try:
+                        response_listpays = cls.stub.ListPays(request_listpays)
+                    except Exception as e:
+                        print(str(e))
 
-                    results = {"succeded": True}
-                    return results
+                    if len(response_listpays.pays) == 0:
+                        results = {
+                            "succeded": False,
+                            "context": f"payment failure reason: Payment for expired invoice not found. Hash: {hash}",
+                        }
+                        return results
 
-            except grpc._channel._InactiveRpcError as e:
-                if "code: Some" in str(e):
-                    status_code = int(e.details().split("code: Some(")[1].split(")")[0])
-                    if (
-                        status_code == 201
-                    ):  # Already paid with this hash using different amount or destination
-                        # i don't think this can happen really, since we don't use the amount_msat in request
-                        # and if you just try 'pay' 2x where the first time it succeeds you get the same
-                        # non-error result the 2nd time.
-                        print(
-                            f"Order: {order.id} ALREADY PAID using different amount or destination THIS SHOULD NEVER HAPPEN! Hash: {hash}.")
+                    still_inflight = False
+                    for pay in response_listpays.pays:
+                        if pay.status == 0:
+                            still_inflight = True
+                        elif pay.status == 2:
+                            print(
+                                f"Order: {order.id} Payment got accepted after invoice expiry! Hash: {hash}")
 
-                    # Permanent failure at destination. or Unable to find a route. or Route too expensive.
-                    elif status_code == 203 or status_code == 205 or status_code == 206 or status_code == 210:
-                        lnpayment.status = LNPayment.Status.FAILRO
+                    if still_inflight:
+                        was_in_transit = True
+                    else:
+                        lnpayment.status = LNPayment.Status.EXPIRE
                         lnpayment.last_routing_time = timezone.now()
-                        lnpayment.routing_attempts += 1
-                        lnpayment.failure_reason = LNPayment.FailureReason.NOROUTE
                         lnpayment.in_flight = False
-                        if lnpayment.routing_attempts > 2:
-                            lnpayment.status = LNPayment.Status.EXPIRE
-                            lnpayment.routing_attempts = 0
                         lnpayment.save(
-                            update_fields=[
-                                "status", "last_routing_time", "routing_attempts", "in_flight", "failure_reason"]
-                        )
-
+                            update_fields=["status", "last_routing_time", "in_flight"])
                         order.status = Order.Status.FAI
                         order.expires_at = timezone.now() + timedelta(
                             seconds=order.t_to_expire(Order.Status.FAI)
                         )
                         order.save(update_fields=["status", "expires_at"])
-                        print(
-                            f"Order: {order.id} FAILED. Hash: {hash} Reason: {cls.payment_failure_context[status_code]}"
-                        )
-                        return {
+                        results = {
                             "succeded": False,
-                            "context": f"payment failure reason: {cls.payment_failure_context[status_code]}",
+                            "context": "The payout invoice has expired",
                         }
-                    elif status_code == 207:  # invoice expired
-                        print(f"Order: {order.id}. INVOICE EXPIRED. Hash: {hash}")
-
-                        request_listpays = noderpc.ListpaysRequest(payment_hash=hash)
-                        try:
-                            response_listpays = cls.stub.ListPays(request_listpays)
-                        except Exception as e:
-                            print(str(e))
-
-                        if len(response_listpays.pays) == 0:
-                            print(
-                                f"Order: {order.id}. UNUSUAL: Payment for expired invoice not found. Hash: {hash}")
-                            continue
-
-                        still_inflight = False
-                        for pay in response_listpays.pays:
-                            if pay.status == 0:
-                                still_inflight = True
-                            elif pay.status == 2:
-                                print(
-                                    f"Order: {order.id} Payment got accepted after invoice expiry! Hash: {hash}")
-
-                        if still_inflight:
-                            was_in_transit = True
-                        else:
-                            lnpayment.status = LNPayment.Status.EXPIRE
-                            lnpayment.last_routing_time = timezone.now()
-                            lnpayment.in_flight = False
-                            lnpayment.save(
-                                update_fields=["status", "last_routing_time", "in_flight"])
-                            order.status = Order.Status.FAI
-                            order.expires_at = timezone.now() + timedelta(
-                                seconds=order.t_to_expire(Order.Status.FAI)
-                            )
-                            order.save(update_fields=["status", "expires_at"])
-                            results = {
-                                "succeded": False,
-                                "context": "The payout invoice has expired",
-                            }
-                            return results
-                    else:  # -1 (general error)
-                        print(str(e))
-                else:
+                        return results
+                else:  # -1 (general error)
                     print(str(e))
+            else:
+                print(str(e))
 
     @classmethod
     def send_keysend(

--- a/api/lightning/lnd.py
+++ b/api/lightning/lnd.py
@@ -607,6 +607,12 @@ class LNDNode:
                     payment_hash=bytes.fromhex(hash)
                 )
 
+                for response in cls.routerstub.TrackPaymentV2(request):
+                    handle_response(response)
+
+            else:
+                print(str(e))
+
     @classmethod
     def send_keysend(
         cls, target_pubkey, message, num_satoshis, routing_budget_sats, timeout, sign
@@ -688,3 +694,7 @@ class LNDNode:
         """Just as it sounds. Better safe than sorry!"""
         request = invoicesrpc.LookupInvoiceMsg(payment_hash=bytes.fromhex(payment_hash))
         response = cls.invoicesstub.LookupInvoiceV2(request)
+
+        return (
+            response.state == 1
+        )  # LND states: 0 OPEN, 1 SETTLED, 3 ACCEPTED, GRPC_ERROR status 5 when cancelled/returned


### PR DESCRIPTION
## What does this PR do?
Fixes several type mismatches
Updated methods to non-deprecated ones in cln 23.05
adopt .save() changes from lnd.py to cln.py
introduces a 100h long fixed invoice expiry, because it gets dirty if you try to accept a htlc for an expired invoice in cln
adopt general changes to follow_send_payment and lookup_invoice_status
fix wrong field used in double_check_htlc_is_settled