### PR TITLE
Add support for multiline chat

### DIFF
--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -332,7 +332,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
                 fullWidth={true}
               />
             </Grid>
-            <Grid item alignItems='stretch' style={{ display: 'flex' }} xs={3}>
+            <Grid item alignItems='flex-end' style={{ display: 'flex' }} xs={3}>
               <Button
                 fullWidth={true}
                 disabled={!connected || waitingEcho || !peerPubKey}

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -312,6 +312,12 @@ const EncryptedSocketChat: React.FC<Props> = ({
                 label={t('Type a message')}
                 variant='standard'
                 size='small'
+                multiline
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    onButtonClicked(e);
+                  }
+                }}
                 helperText={
                   connected
                     ? peerPubKey

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -313,6 +313,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
                 variant='standard'
                 size='small'
                 multiline
+                maxRows={3}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && !e.shiftKey) {
                     onButtonClicked(e);
@@ -332,7 +333,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
                 fullWidth={true}
               />
             </Grid>
-            <Grid item alignItems='flex-end' style={{ display: 'flex' }} xs={3}>
+            <Grid item alignItems='stretch' style={{ display: 'flex' }} xs={3}>
               <Button
                 fullWidth={true}
                 disabled={!connected || waitingEcho || !peerPubKey}

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
@@ -300,6 +300,7 @@ const EncryptedTurtleChat: React.FC<Props> = ({
                 variant='standard'
                 size='small'
                 multiline
+                maxRows={3}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter' && !e.shiftKey) {
                     onButtonClicked(e);
@@ -312,7 +313,7 @@ const EncryptedTurtleChat: React.FC<Props> = ({
                 fullWidth={true}
               />
             </Grid>
-            <Grid item alignItems='flex-end' style={{ display: 'flex' }} xs={3}>
+            <Grid item alignItems='stretch' style={{ display: 'flex' }} xs={3}>
               <Button
                 disabled={waitingEcho || !peerPubKey}
                 type='submit'

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
@@ -312,7 +312,7 @@ const EncryptedTurtleChat: React.FC<Props> = ({
                 fullWidth={true}
               />
             </Grid>
-            <Grid item alignItems='stretch' style={{ display: 'flex' }} xs={3}>
+            <Grid item alignItems='flex-end' style={{ display: 'flex' }} xs={3}>
               <Button
                 disabled={waitingEcho || !peerPubKey}
                 type='submit'

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
@@ -299,6 +299,12 @@ const EncryptedTurtleChat: React.FC<Props> = ({
                 label={t('Type a message')}
                 variant='standard'
                 size='small'
+                multiline
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    onButtonClicked(e);
+                  }
+                }}
                 value={value}
                 onChange={(e) => {
                   setValue(e.target.value);

--- a/frontend/src/components/TradeBox/EncryptedChat/MessageCard/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/MessageCard/index.tsx
@@ -126,7 +126,14 @@ const MessageCard: React.FC<Props> = ({ message, isTaker, userConnected, baseUrl
               {message.encryptedMessage}{' '}
             </a>
           ) : (
-            message.plainTextMessage
+            <>
+              {message.plainTextMessage.split('\n').map((messageLine, idx) => (
+                <span key={idx}>
+                  {messageLine}
+                  <br />
+                </span>
+              ))}
+            </>
           )
         }
         subheaderTypographyProps={{


### PR DESCRIPTION
## What does this PR do?
Fixes #562 

This PR adds multiline support to the TextInput field in the Encrypted{Turtle|Socket}Chat components. 

Everything behaves as before, except now if you hit shift-enter it will add a newline. Enter will still submit. Users can also paste text with multiple lines.

### Testing
- Tested on Firefox and Chrome.
- Wasn't able to get the APK pointed at testnet, so still needs to be tested on Android.

There is a question on styling of the Send button since the multiline now moves everything down. See below.

### Default Styling
This is with `alignItems='stretch'` on the parent Grid of the button

<img src="https://github.com/RoboSats/robosats/assets/116033104/8f55d1df-fb68-4d11-b88f-988f9c533fef" width=400 align=left/>

<br/>

<img src="https://github.com/RoboSats/robosats/assets/116033104/8d3ee93c-af3e-4498-bb21-17229f913dca" width=400 align=left/>

### Changing styling
This is with `alignItems='flex-end'`. I think I prefer this one.

<img src="https://github.com/RoboSats/robosats/assets/116033104/674c48bf-ea97-4f06-a339-018407b54753" width=400 align=left/>

<br/>

<img src="https://github.com/RoboSats/robosats/assets/116033104/da6cb4c7-8bad-44a7-bdb1-35bc549e10b8" width=400 align=left/>

## Checklist before merging
- [✅] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [N/A] If I added new phrases to the user interface, I have ran `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.