### PR TITLE
Fix collect_phrases.py to work on all OS

### DIFF
--- a/frontend/static/locales/handcrafted.py
+++ b/frontend/static/locales/handcrafted.py
@@ -1,36 +1,76 @@
+from collections import OrderedDict
+
 # Some of the phrases that are directly returned by the coordinator API (bad requests)
 # or need the use of tags <></>.
-phrases = {
-    "desktop_unsafe_alert": "Some features are disabled for your protection (e.g. chat) and you will not be able to complete a trade without them. To protect your privacy and fully enable RoboSats, use <1>Tor Browser</1> and visit the <3>Onion</3> site.",
-    "phone_unsafe_alert": "You will not be able to complete a trade. Use <1>Tor Browser</1> and visit the <3>Onion</3> site.",
-    "rate_robosats": "What do you think of <1>RoboSats</1>?",
-    "let_us_know_hot_to_improve": "Let us know how the platform could improve (<1>Telegram</1> / <3>Github</3>)",
-    "open_dispute": "To open a dispute you need to wait <1><1/>",
-    "Waiting for maker bond": "Waiting for maker bond",
-    "Public": "Public",
-    "Waiting for taker bond": "Waiting for taker bond",
-    "Cancelled": "Cancelled",
-    "Expired": "Expired",
-    "Waiting for trade collateral and buyer invoice": "Waiting for trade collateral and buyer invoice",
-    "Waiting only for seller trade collateral": "Waiting only for seller trade collateral",
-    "Waiting only for buyer invoice": "Waiting only for buyer invoice",
-    "Sending fiat - In chatroom": "Sending fiat - In chatroom",
-    "Fiat sent - In chatroom": "Fiat sent - In chatroom",
-    "In dispute": "In dispute",
-    "Collaboratively cancelled": "Collaboratively cancelled",
-    "Sending satoshis to buyer": "Sending satoshis to buyer",
-    "Sucessful trade": "Successful trade",
-    "Failed lightning network routing": "Failed lightning network routing",
-    "Wait for dispute resolution": "Wait for dispute resolution",
-    "Maker lost dispute": "Maker lost dispute",
-    "Taker lost dispute": "Taker lost dispute",
-    "Invoice expired. You did not confirm publishing the order in time. Make a new order.": "Invoice expired. You did not confirm publishing the order in time. Make a new order.",
-    "This order has been cancelled by the maker": "This order has been cancelled by the maker",
-    "Invoice expired. You did not confirm taking the order in time.": "Invoice expired. You did not confirm taking the order in time.",
-    "Invalid Order Id": "Invalid Order Id",
-    "Invoice expired. You did not confirm taking the order in time.": "Invoice expired. You did not confirm taking the order in time.",
-    "You must have a robot avatar to see the order details": "You must have a robot avatar to see the order details",
-    "This order has been cancelled collaborativelly": "This order has been cancelled collaboratively",
-    "This order is not available": "This order is not available",
-    "The Robotic Satoshis working in the warehouse did not understand you. Please, fill a Bug Issue in Github https://github.com/RoboSats/robosats/issues": "The Robotic Satoshis working in the warehouse did not understand you. Please, fill a Bug Issue in Github https://github.com/RoboSats/robosats/issues",
-}
+phrases = OrderedDict(
+    [
+        (
+            "desktop_unsafe_alert",
+            "Some features are disabled for your protection (e.g. chat) and you will not be able to complete a trade without them. To protect your privacy and fully enable RoboSats, use <1>Tor Browser</1> and visit the <3>Onion</3> site.",
+        ),
+        (
+            "phone_unsafe_alert",
+            "You will not be able to complete a trade. Use <1>Tor Browser</1> and visit the <3>Onion</3> site.",
+        ),
+        ("rate_robosats", "What do you think of <1>RoboSats</1>?"),
+        (
+            "let_us_know_hot_to_improve",
+            "Let us know how the platform could improve (<1>Telegram</1> / <3>Github</3>)",
+        ),
+        ("open_dispute", "To open a dispute you need to wait <1><1/>"),
+        ("Waiting for maker bond", "Waiting for maker bond"),
+        ("Public", "Public"),
+        ("Waiting for taker bond", "Waiting for taker bond"),
+        ("Cancelled", "Cancelled"),
+        ("Expired", "Expired"),
+        (
+            "Waiting for trade collateral and buyer invoice",
+            "Waiting for trade collateral and buyer invoice",
+        ),
+        (
+            "Waiting only for seller trade collateral",
+            "Waiting only for seller trade collateral",
+        ),
+        ("Waiting only for buyer invoice", "Waiting only for buyer invoice"),
+        ("Sending fiat - In chatroom", "Sending fiat - In chatroom"),
+        ("Fiat sent - In chatroom", "Fiat sent - In chatroom"),
+        ("In dispute", "In dispute"),
+        ("Collaboratively cancelled", "Collaboratively cancelled"),
+        ("Sending satoshis to buyer", "Sending satoshis to buyer"),
+        ("Sucessful trade", "Successful trade"),
+        ("Failed lightning network routing", "Failed lightning network routing"),
+        ("Wait for dispute resolution", "Wait for dispute resolution"),
+        ("Maker lost dispute", "Maker lost dispute"),
+        ("Taker lost dispute", "Taker lost dispute"),
+        (
+            "Invoice expired. You did not confirm publishing the order in time. Make a new order.",
+            "Invoice expired. You did not confirm publishing the order in time. Make a new order.",
+        ),
+        (
+            "This order has been cancelled by the maker",
+            "This order has been cancelled by the maker",
+        ),
+        (
+            "Invoice expired. You did not confirm taking the order in time.",
+            "Invoice expired. You did not confirm taking the order in time.",
+        ),
+        ("Invalid Order Id", "Invalid Order Id"),
+        (
+            "Invoice expired. You did not confirm taking the order in time.",
+            "Invoice expired. You did not confirm taking the order in time.",
+        ),
+        (
+            "You must have a robot avatar to see the order details",
+            "You must have a robot avatar to see the order details",
+        ),
+        (
+            "This order has been cancelled collaborativelly",
+            "This order has been cancelled collaboratively",
+        ),
+        ("This order is not available", "This order is not available"),
+        (
+            "The Robotic Satoshis working in the warehouse did not understand you. Please, fill a Bug Issue in Github https://github.com/RoboSats/robosats/issues",
+            "The Robotic Satoshis working in the warehouse did not understand you. Please, fill a Bug Issue in Github https://github.com/RoboSats/robosats/issues",
+        ),
+    ]
+)


### PR DESCRIPTION
Changed handcrafted.py to use a OrderedDict instead of a dict (guarantee the order independant of the python 3.x version)

Moved the value of "../../src" to the variable "src_path" to improve readability, and reuse the value again later in code

Changed the "Look for all matching i18n keys" part of code to order the dirs and file in a independant OS way - alphabetical order using the "sort" func of list object

Changed the "Look for all matching i18n keys" part of code to collect all phrases in a OrderedDict (guarantee the order independant of the python 3.x version) and sort the matches

Changed the list indexing in filepath var (filepath[10:]) to the use of os.path.relpath(filepath, src_path) func to improve readability

Changed all_phrases to a OrderedDict (guarantee the order independant of the python version) and use update method of OrderedDict to add the files's phrases and handcrafted phrases to the OrderedDict in order

Changed the loop of matches to inside the if statement (if len(matches) > 0) to improve readability - if the "if statement" is false, the loop was never executed

Changed the "Load existing locale dics and replace keys" part of code to use OrderedDict in the new_phrases var to guarantee the order of the keys insert in json.dump in all OS

Changed the "Load existing locale dics and replace keys" part of code to not substitute the keys "#{counter}" to guarantee the order independant of the json file of the translation.

## What does this PR do?
Fixes #590 

This PR refactor the "frontend/static/locales/collect_phrases.py" and "frontend/static/locales/handcrafted.py" to be python 3.x version independent and OS independent (Using OrderedDict and sorts).

The order of the resulting json files is not same of before. Now the files's name and phrases inside the files are order alphabetically. The handcrafted phrases are order by insertion in original python file.

I think the order of the phrases can be the insertion order in the original Typescript/Javascript file, if needed, but the order of the files's name must be alphabetically in json.

Following 3 json files (PT) to represent the json before change in windows and linux and after change:
- [jsons.zip](https://github.com/RoboSats/robosats/files/11524966/jsons.zip)

## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [N/A] If I added new phrases to the user interface, I have ran `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.