### PR TITLE
Fetch lnproxy relay list from lnproxy repo

### DIFF
--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Fetch and process JSON
         run: |
-          curl https://raw.githubusercontent.com/shyfire131/lnproxy-webui2/17d6131a72a92978e5c0dc57ab2b2fbe467c7722/assets/relays.json -o lnproxy_tmplist.json
+          curl https://raw.githubusercontent.com/lnproxy/lnproxy-webui2/main/assets/relays.json -o lnproxy_tmplist.json
           node .github/workflows/scripts/lnproxy-sync.js
 
       - name: Commit and push if it's not up to date

--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch and process JSON
         run: |


### PR DESCRIPTION
My changes have been merged into main on the lnproxy repo, so RoboSats must not fetch from my fork of lnproxy anymore.

## What does this PR do?
This is a minor addendum to https://github.com/RoboSats/robosats/pull/586

## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [N/A] If I added new phrases to the user interface, I have ran `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.