### PR TITLE
Additional updates to LnProxy support

### DIFF
--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -3,11 +3,14 @@ name: Sync lnproxy relays
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0 12 * * 0'  # Run every Sunday at noon
+    - cron: "0 12 * * 0" # Run every Sunday at noon
 
 jobs:
   sync:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Fetch and process JSON
         run: |
-          curl https://raw.githubusercontent.com/shyfire131/lnproxy-webui2/17d6131a72a92978e5c0dc57ab2b2fbe467c7722/assets/relays.json -o lnproxy_tmplist.json
+          curl https://raw.githubusercontent.com/lnproxy/lnproxy-webui2/main/assets/relays.json -o lnproxy_tmplist.json
           node .github/workflows/scripts/lnproxy-sync.js
 
       - name: Commit and push if it's not up to date

--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch and process JSON
         run: |


### PR DESCRIPTION
## What does this PR do?
1. Fixes the failed action issue raised in matrix devchat
2. Corrects where the relay list is being fetched from - don't fetch from fork anymore
3. Bumps the `action/checkout` dependency from v2 to v3

Regarding the reason that the action was failing, this was most likely because the Robosats workflow permissions are set to the most restrictive setting:

---
![image](https://github.com/RoboSats/robosats/assets/116033104/78dea9ae-03d0-4616-bbc9-64e494f37471)
---

More info on the permissions syntax used can be found here:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.
- [N/A] If I added new phrases to the user interface, I have ran `cd frontend/static/locales; python collect_phrases.py` to collect them for translation.