### PR TITLE
Submit PRs for LnProxy relay list updates

### DIFF
--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -11,23 +11,30 @@ jobs:
 
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Fetch and process JSON
+      - name: Fetch and process lnproxy relay JSON file
         run: |
           curl https://raw.githubusercontent.com/lnproxy/lnproxy-webui2/main/assets/relays.json -o lnproxy_tmplist.json
           node .github/workflows/scripts/lnproxy-sync.js
-
-      - name: Commit and push if it's not up to date
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
           git add ./frontend/static/lnproxies.json
-          git diff --quiet && git diff --staged --quiet || git commit -m "Update LNProxy relay list"
-          git push
 
       - name: Remove tmp lnproxy json file
         run: rm lnproxy_tmplist.json
+
+      - name: Get the date for use in subsequent steps
+        id: getdate
+        run: echo "current_date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Submit pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: "Update LNProxy relay list on ${{ env.current_date }}"
+          committer: GitHub Action <action@github.com>
+          branch: "lnproxy-${{ env.current_date }}"
+          delete-branch: true
+          title: "[GitHub Action] Update LNProxy relay list ${{ env.current_date }}"


### PR DESCRIPTION
LnProxy - the feature that is never done!

See comments [here](https://github.com/RoboSats/robosats/pull/609) for context.

This PR updates the workflow to submit PRs with relay updates instead of making commits directly.

## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.