### PR TITLE
Fix bug in discount field

### DIFF
--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -181,27 +181,28 @@ const MakerForm = ({
     });
   };
 
-  const handlePremiumChange = function (e: object) {
-    const max = fav.mode === 'fiat' ? 999 : 99;
-    const min = -100;
-    const newPremium = Math.floor(e.target.value * Math.pow(10, 2)) / Math.pow(10, 2);
-    let premium: number = newPremium;
-    let badPremiumText: string = '';
-    if (newPremium > 999) {
-      badPremiumText = t('Must be less than {{max}}%', { max });
-      premium = 999;
-    } else if (newPremium <= -100) {
-      badPremiumText = t('Must be more than {{min}}%', { min });
-      premium = -99.99;
-    }
-    updateCurrentPrice(limits.list, fav.currency, premium);
-    updateAmountLimits(limits.list, fav.currency, premium);
-    setMaker({
-      ...maker,
-      premium,
-      badPremiumText,
-    });
-  };
+  const handlePremiumChange: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement> =
+    function ({ target: { value } }) {
+      const max = fav.mode === 'fiat' ? 999 : 99;
+      const min = -100;
+      const newPremium = Math.floor(Number(value) * Math.pow(10, 2)) / Math.pow(10, 2);
+      let premium: number = isNaN(newPremium) ? 0 : newPremium;
+      let badPremiumText: string = '';
+      if (newPremium > 999) {
+        badPremiumText = t('Must be less than {{max}}%', { max });
+        premium = 999;
+      } else if (newPremium <= -100) {
+        badPremiumText = t('Must be more than {{min}}%', { min });
+        premium = -99.99;
+      }
+      updateCurrentPrice(limits.list, fav.currency, premium);
+      updateAmountLimits(limits.list, fav.currency, premium);
+      setMaker({
+        ...maker,
+        premium: isNaN(newPremium) || value === '' ? '' : premium,
+        badPremiumText,
+      });
+    };
 
   const handleSatoshisChange = function (e: object) {
     const newSatoshis = e.target.value;

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... en algun indret de la Terra!",
   "24h contracted volume": "Volum contractat en 24h",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinador",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/collect_phrases.py
+++ b/frontend/static/locales/collect_phrases.py
@@ -47,7 +47,7 @@ locales = [f for f in os.listdir(".") if f.endswith(".json")]
 for locale in locales:
     new_phrases = OrderedDict()
     with open(locale, "r", encoding="utf-8") as f:
-        old_phrases = json.load(f)
+        old_phrases = json.load(f, object_pairs_hook=OrderedDict)
         for key in all_phrases.keys():
             # update dictionary with new keys on /src/, but ignore the counter of files keys
             if key in old_phrases and not re.match(r"^#\d+$", key):
@@ -55,8 +55,10 @@ for locale in locales:
             else:
                 new_phrases[key] = all_phrases[key]
 
-    with open(locale, "w", encoding="utf-8") as f:
-        json.dump(new_phrases, f, ensure_ascii=False)
+    # don't change the file if there aren't new keys (order matters)
+    if new_phrases != old_phrases:
+        with open(locale, "w", encoding="utf-8") as f:
+            json.dump(new_phrases, f, ensure_ascii=False)
 
 with open("./collected_phrases.json", "w", encoding="utf-8") as f:
     json.dump(all_phrases, f, ensure_ascii=False)

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... někde na Zemi!",
   "24h contracted volume": "Zobchodované množství za 24h",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... irgendwo auf der Erde!",
   "24h contracted volume": "24h Handelsvolumen",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... somewhere on Earth!",
   "24h contracted volume": "24h contracted volume",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... en algún lugar de La Tierra!",
   "24h contracted volume": "Volumen de los contratos en 24h",
+  "CLN version": "CLN version",
   "Client": "Cliente",
   "Coordinator": "Coordinador",
   "Coordinator commit hash": "Hash de confirmación del coordinador",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... Lurreko lekuren batean!",
   "24h contracted volume": "24 ordutan kontratatutako bolumena",
+  "CLN version": "CLN version",
   "Client": "Bezeroa",
   "Coordinator": "Koordinatzailea",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... quelque part sur Terre!",
   "24h contracted volume": "Volume contracté en 24h",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... da qualche parte sulla Terra!",
   "24h contracted volume": "Volume scambiato in 24h",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "......地球上のどっかから！",
   "24h contracted volume": "24時間の契約量",
+  "CLN version": "CLN version",
   "Client": "クライアント",
   "Coordinator": "コーディネーター",
   "Coordinator commit hash": "コーディネーターコミットハッシュ",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... gdzieś na Ziemi!",
   "24h contracted volume": "Zakontraktowana objętość 24h",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... alguém na terra!",
   "24h contracted volume": "Volume contratado em 24h",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... где-то на земле!",
   "24h contracted volume": "Объём контрактов за 24 часа",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... någonstans på jorden!",
   "24h contracted volume": "24h kontrakterad volym",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "... ซักที่ บนโลกใบนี้!",
   "24h contracted volume": "24h ปริมาณการซื้อขาย 24 ชั่วโมงที่แล้ว",
+  "CLN version": "CLN version",
   "Client": "Client",
   "Coordinator": "Coordinator",
   "Coordinator commit hash": "Coordinator commit hash",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "...在世界上某处建造！",
   "24h contracted volume": "24小时合约量",
+  "CLN version": "CLN version",
   "Client": "客户端",
   "Coordinator": "协调器",
   "Coordinator commit hash": "协调器提交哈希",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -268,6 +268,7 @@
   "#26": "Phrases in components/Dialogs/Stats.tsx",
   "... somewhere on Earth!": "...在世界上某處製造！",
   "24h contracted volume": "24小時合約量",
+  "CLN version": "CLN version",
   "Client": "客戶端",
   "Coordinator": "協調器",
   "Coordinator commit hash": "協調器提交哈希",


### PR DESCRIPTION
Fixing the type handlePremiumChange function to handle the discount to the right type (React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement>)

Using the correct type of handlePremiumChange function, then deconstructing the "value" var from the event.target

Using Number(value) in declaration of "newPremium", instead of using multiplication with number and string

To not affect another methods using "premium" var, I used isNaN func to make a check and set the initial value of "premium" var to zero (if is NaN) or newPremium (when valid number is entered)

The fix in the bug is the line "premium: isNaN(newPremium) || value === '' ? '' : premium," in setMaker. That makes the "premium" var to be set to zero when the input is empty or not a number, allowing the user to input the "-" (minus sign) and not entering 0 as before.

## What does this PR do?
Fixes #532

This PR fix the bug in discount field changing the function `handlePremiumChange` in "frontend/src/components/MakerForm/MakerForm.tsx". 
This changes "frontend/static/locales/collect_phrases.py" too, because the pre-commit was running in loop, changing the locales's json. I added a comparison in the python script to not update the json if he no has changes.


## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.