### PR TITLE
Deprecate unsigned invoices

### DIFF
--- a/api/oas_schemas.py
+++ b/api/oas_schemas.py
@@ -205,7 +205,7 @@ class OrderViewSchema:
             Update an order
 
             `action` field is required and determines what is to be done. Below
-            is an explaination of what each action does:
+            is an explanation of what each action does:
 
             - `take`
               - If the order has not expired and is still public, on a
@@ -220,13 +220,14 @@ class OrderViewSchema:
             - `update_invoice`
               - This action only is valid if you are the buyer. The `invoice`
                 field needs to be present in the body and the value must be a
-                valid LN invoice. Make sure to perform this action only when
+                valid LN invoice as cleartext PGP message signed with the robot key. Make sure to perform this action only when
                 both the bonds are locked. i.e The status of your order is
-                atleast `6` (Waiting for trade collateral and buyer invoice)
+                at least `6` (Waiting for trade collateral and buyer invoice)
             - `update_address`
               - This action is only valid if you are the buyer. This action is
                 used to set an on-chain payout address if you wish to have your
-                payout be recieved on-chain. This enables on-chain swap for the
+                payout be received on-chain. Only valid if there is an address in the body as
+                cleartext PGP message signed with the robot key. This enables on-chain swap for the
                 order, so even if you earlier had submitted a LN invoice, it
                 will be ignored. You get to choose the `mining_fee_rate` as
                 well. Mining fee rate is specified in sats/vbyte.
@@ -237,7 +238,7 @@ class OrderViewSchema:
                 - `11` - In dispute
                 - `12` - Collaboratively cancelled
                 - `13` - Sending satoshis to buyer
-                - `14` - Sucessful trade
+                - `14` - Successful trade
                 - `15` - Failed lightning network routing
                 - `17` - Maker lost dispute
                 - `18` - Taker lost dispute
@@ -246,13 +247,13 @@ class OrderViewSchema:
                 mid-trade so use this action carefully:
 
                 - As a maker if you cancel an order after you have locked your
-                  maker bond, you are returend your bond. This may change in
+                  maker bond, you are returned your bond. This may change in
                   the future to prevent DDoSing the LN node and you won't be
-                  returend the maker bond.
+                  returned the maker bond.
                 - As a taker there is a time penalty involved if you `take` an
                   order and cancel it without locking the taker bond.
                 - For both taker or maker, if you cancel the order when both
-                  have locked thier bonds (status = `6` or `7`), you loose your
+                  have locked their bonds (status = `6` or `7`), you loose your
                   bond and a percent of it goes as "rewards" to your
                   counterparty and some of it the platform keeps. This is to
                   discourage wasting time and DDoSing the platform.
@@ -761,7 +762,7 @@ class InfoViewSchema:
 class RewardViewSchema:
     post = {
         "summary": "Withdraw reward",
-        "description": "Withdraw user reward by submitting an invoice",
+        "description": "Withdraw user reward by submitting an invoice. The invoice must be send as cleartext PGP message signed with the robot key",
         "responses": {
             200: {
                 "type": "object",

--- a/api/views.py
+++ b/api/views.py
@@ -547,14 +547,9 @@ class OrderView(viewsets.ViewSet):
         # 2) If action is 'update invoice'
         elif action == "update_invoice":
             # DEPRECATE post v0.5.1.
-            if "---" not in pgp_invoice:
-                valid_signature = True
-                invoice = pgp_invoice
-            else:
-                # END DEPRECATE.
-                valid_signature, invoice = verify_signed_message(
-                    request.user.robot.public_key, pgp_invoice
-                )
+            valid_signature, invoice = verify_signed_message(
+                request.user.robot.public_key, pgp_invoice
+            )
 
             if not valid_signature:
                 return Response(
@@ -570,15 +565,9 @@ class OrderView(viewsets.ViewSet):
 
         # 2.b) If action is 'update address'
         elif action == "update_address":
-            # DEPRECATE post v0.5.1.
-            if "---" not in pgp_address:
-                valid_signature = True
-                address = pgp_address
-            else:
-                # END DEPRECATE.
-                valid_signature, address = verify_signed_message(
-                    request.user.robot.public_key, pgp_address
-                )
+            valid_signature, address = verify_signed_message(
+                request.user.robot.public_key, pgp_address
+            )
 
             if not valid_signature:
                 return Response(
@@ -1031,15 +1020,9 @@ class RewardView(CreateAPIView):
 
         pgp_invoice = serializer.data.get("invoice")
 
-        # DEPRECATE post v0.5.1.
-        if "---" not in pgp_invoice:
-            valid_signature = True
-            invoice = pgp_invoice
-        else:
-            # END DEPRECATE.
-            valid_signature, invoice = verify_signed_message(
-                request.user.robot.public_key, pgp_invoice
-            )
+        valid_signature, invoice = verify_signed_message(
+            request.user.robot.public_key, pgp_invoice
+        )
 
         if not valid_signature:
             return Response(

--- a/frontend/src/components/Notifications/index.tsx
+++ b/frontend/src/components/Notifications/index.tsx
@@ -35,6 +35,7 @@ const path =
   window.NativeRobosats === undefined
     ? '/static/assets/sounds'
     : 'file:///android_asset/Web.bundle/assets/sounds';
+
 const audio = {
   chat: new Audio(`${path}/chat-open.mp3`),
   takerFound: new Audio(`${path}/taker-found.mp3`),

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -16,6 +16,11 @@ import { type EncryptedChatMessage, type ServerMessage } from '..';
 import ChatBottom from '../ChatBottom';
 import { sha256 } from 'js-sha256';
 
+const audioPath =
+  window.NativeRobosats === undefined
+    ? '/static/assets/sounds'
+    : 'file:///android_asset/Web.bundle/assets/sounds';
+
 interface Props {
   orderId: number;
   status: number;
@@ -44,7 +49,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
   const { t } = useTranslation();
   const theme = useTheme();
 
-  const [audio] = useState(() => new Audio(`/static/assets/sounds/chat-open.mp3`));
+  const [audio] = useState(() => new Audio(`${audioPath}/chat-open.mp3`));
   const [connected, setConnected] = useState<boolean>(false);
   const [peerConnected, setPeerConnected] = useState<boolean>(false);
   const [peerPubKey, setPeerPubKey] = useState<string>();
@@ -268,7 +273,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
       />
       <Grid item>
         <ChatHeader
-          connected={connected}
+          connected={connected && (peerPubKey ? true : false)}
           peerConnected={peerConnected}
           turtleMode={turtleMode}
           setTurtleMode={setTurtleMode}

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedTurtleChat/index.tsx
@@ -28,6 +28,11 @@ interface Props {
   setTurtleMode: (state: boolean) => void;
 }
 
+const audioPath =
+  window.NativeRobosats === undefined
+    ? '/static/assets/sounds'
+    : 'file:///android_asset/Web.bundle/assets/sounds';
+
 const EncryptedTurtleChat: React.FC<Props> = ({
   orderId,
   robot,
@@ -43,7 +48,7 @@ const EncryptedTurtleChat: React.FC<Props> = ({
   const { t } = useTranslation();
   const theme = useTheme();
 
-  const [audio] = useState(() => new Audio(`/static/assets/sounds/chat-open.mp3`));
+  const [audio] = useState(() => new Audio(`${audioPath}/chat-open.mp3`));
   const [peerConnected, setPeerConnected] = useState<boolean>(false);
   const [peerPubKey, setPeerPubKey] = useState<string>();
   const [value, setValue] = useState<string>('');
@@ -255,7 +260,7 @@ const EncryptedTurtleChat: React.FC<Props> = ({
 
       <Grid item>
         <ChatHeader
-          connected={true}
+          connected={peerPubKey ? true : false}
           peerConnected={peerConnected}
           turtleMode={turtleMode}
           setTurtleMode={setTurtleMode}


### PR DESCRIPTION
## What does this PR do?
This PR deletes the possibility of submitting unsigned addresses and invoices. Now all invoices must be PGP signed with the robot key. This is a security measure to verify only the owner of the robot token can submit an invoice: therefore, reducing the risk of man in the middle (e.g., someone gets the header Auth token by running a robosats proxy, will not has access to the robot token and will not be able to it's own invoice/address)

Only frontends post v0.5.1-alpha will sign all invoices / addresses by default.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.