### PR TITLE
use base-ex hex converter / correct fn name

### DIFF
--- a/frontend/src/utils/hexToBase91.ts
+++ b/frontend/src/utils/hexToBase91.ts
@@ -1,10 +1,8 @@
-import { Base91 } from 'base-ex';
+import { Base16, Base91 } from 'base-ex';
 
-export default function hexToBase85(hex: string): string {
-  const hexes = hex.match(/.{1,2}/g);
-  if (hexes == null) return '';
-  const byteArray = hexes.map((byte) => parseInt(byte, 16));
+export default function hexToBase91(hex: string): string {
+  const b16 = new Base16();
   const b91 = new Base91();
-  const base91string = b91.encode(new Uint8Array(byteArray));
+  const base91string = b91.encode(b16.decode(hex));
   return base91string;
 }


### PR DESCRIPTION
## What does this PR do?
This PR refactors the **hexToBase91** function. The hex string is decoded with the **Base16** `decode` function of **BaseEx**. As BaseEx is getting used already, it makes sense to use this other feature.   

Also the name is fixed (originally it was called hexToBase85). 

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.