### PR TITLE
Updated BBW to Blink Wallet

### DIFF
--- a/docs/_pages/docs/03-understand/07-wallets.md
+++ b/docs/_pages/docs/03-understand/07-wallets.md
@@ -38,7 +38,7 @@ This is a non-exhaustive compilation based on past experience of users. We have 
 |[Blue](#bluewallet-mobile)|[1.4.4](https://bluewallet.io/)|{{page.phone}}|{{page.good}}|{{page.unclear}}|{{page.unclear}}|{{page.good}}|{{page.unclear}}|
 |[WoS](https://github.com/RoboSats/robosats/issues/44#issue-1135544303)|[1.15.0](https://www.walletofsatoshi.com/)|{{page.phone}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.thumbsup}}|
 |[Phoenix](#phoenix-mobile)|[35-1.4.20](https://phoenix.acinq.co/)|{{page.phone}}|{{page.good}}|{{page.soso}}|{{page.good}}|{{page.good}}|{{page.unclear}}|
-|[Blink](#blink-wallet)|[2.2.67](https://www.blink.sv/)|{{page.phone}}|{{page.unclear}}|{{page.good}}|{{page.good}}|{{page.good}} |{{page.unclear}}|(https://github.com/RoboSats/robosats/issues/44#issuecomment-1126318591)|
+|[Blink](#blink-mobile-former-bitcoin-beach-wallet)|[2.2.67](https://www.blink.sv/)|{{page.phone}}|{{page.unclear}}|{{page.good}}|{{page.good}}|{{page.good}} |{{page.unclear}}|(https://github.com/RoboSats/robosats/issues/44#issuecomment-1126318591)|
 |[Alby](#alby-browser-extension)|[v1.14.2](https://github.com/getAlby/lightning-browser-extension)|{{page.laptop}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.good}} |{{page.thumbsup}}|
 
 1. **UX:** Does the wallet convey clearly that there is an "ongoing" payment (hodl invoice)?

--- a/docs/_pages/docs/03-understand/07-wallets.md
+++ b/docs/_pages/docs/03-understand/07-wallets.md
@@ -38,7 +38,7 @@ This is a non-exhaustive compilation based on past experience of users. We have 
 |[Blue](#bluewallet-mobile)|[1.4.4](https://bluewallet.io/)|{{page.phone}}|{{page.good}}|{{page.unclear}}|{{page.unclear}}|{{page.good}}|{{page.unclear}}|
 |[WoS](https://github.com/RoboSats/robosats/issues/44#issue-1135544303)|[1.15.0](https://www.walletofsatoshi.com/)|{{page.phone}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.thumbsup}}|
 |[Phoenix](#phoenix-mobile)|[35-1.4.20](https://phoenix.acinq.co/)|{{page.phone}}|{{page.good}}|{{page.soso}}|{{page.good}}|{{page.good}}|{{page.unclear}}|
-|[{{page.bitcoin}} Beach](#bitcoin-beach-mobile)|[v1.7.7](https://galoy.io/bitcoin-beach-wallet/)|{{page.phone}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.good}} |[{{page.thumbsup}}](https://github.com/RoboSats/robosats/issues/44#issuecomment-1126318591)|
+|[Blink](#blink-wallet)|[2.2.67](https://www.blink.sv/)|{{page.phone}}|{{page.unclear}}|{{page.good}}|{{page.good}}|{{page.good}} |{{page.unclear}}|(https://github.com/RoboSats/robosats/issues/44#issuecomment-1126318591)|
 |[Alby](#alby-browser-extension)|[v1.14.2](https://github.com/getAlby/lightning-browser-extension)|{{page.laptop}}|{{page.good}}|{{page.good}}|{{page.good}}|{{page.good}} |{{page.thumbsup}}|
 
 1. **UX:** Does the wallet convey clearly that there is an "ongoing" payment (hodl invoice)?
@@ -78,8 +78,8 @@ Phoenix works very well as an order taker. Phoenix will also work well as an ord
 ### Bluewallet (Mobile)
 It works well. But they are having issues in the custodial mode. Escrows that RoboSats returns are charged to users (so Bluewallet is keeping that balance?). Bonds that are slashed...are charged twice by Blue! More info once they reply to us. EDIT: Blue has confirmed they are working to soon solve these accounting bugs!
 
-### Bitcoin Beach (Mobile)
-The hodl invoice shows as a grey icon while waiting. Need to tap the obvious back button to return to the main screen while the payment is pending.
+### Blink (Mobile, former Bitcoin Beach Wallet)
+Currently hodl invoices don't work correctly and get charged to users, bonds which are older than some minutes are lost. Payouts work fine.
 
 ### OBW (Mobile)
 One of the simplest and one of the best. The hodl invoice shows as "on fly", it is no custodial and it allows to create our own channels, to buy one from a liquidity provider or use Hosted Channels. It is maintained by the great Fiatjaf and it is a fork of the abandoned SBW.


### PR DESCRIPTION
Updated the Wallet Compatibility list. Bitcoin Beach Wallet is now Blink Wallet. Hodl invoices don't work correctly in Blink Wallet yet.

Couldn't get the hyperlink to the paragraph to make the Blink in the table clickable, this should be added before merging.