### PR TITLE
Update handleCurrencyChange to not reset amount range on currency change in maker form

### DIFF
--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -140,11 +140,17 @@ const MakerForm = ({
     updateCurrentPrice(limits.list, newCurrency, maker.premium);
 
     if (makerHasAmountRange) {
-      setMaker({
-        ...maker,
-        minAmount: parseFloat(Number(limits.list[newCurrency].max_amount * 0.25).toPrecision(2)),
-        maxAmount: parseFloat(Number(limits.list[newCurrency].max_amount * 0.75).toPrecision(2)),
-      });
+      const min_amount = parseFloat(Number(limits.list[newCurrency].min_amount).toPrecision(2));
+      const max_amount = parseFloat(Number(limits.list[newCurrency].max_amount).toPrecision(2));
+      if (parseFloat(maker.minAmount) < min_amount || parseFloat(maker.minAmount) > max_amount
+      || parseFloat(maker.maxAmount) > max_amount || parseFloat(maker.maxAmount) < min_amount)
+      {
+        setMaker({
+          ...maker,
+          minAmount: parseFloat(Number(limits.list[newCurrency].max_amount * 0.25).toPrecision(2)),
+          maxAmount: parseFloat(Number(limits.list[newCurrency].max_amount * 0.75).toPrecision(2)),
+        });
+      };
     }
   };
 

--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -140,15 +140,15 @@ const MakerForm = ({
     updateCurrentPrice(limits.list, newCurrency, maker.premium);
 
     if (makerHasAmountRange) {
-      const min_amount = parseFloat(Number(limits.list[newCurrency].min_amount).toPrecision(2));
-      const max_amount = parseFloat(Number(limits.list[newCurrency].max_amount).toPrecision(2));
-      if (parseFloat(maker.minAmount) < min_amount || parseFloat(maker.minAmount) > max_amount
-      || parseFloat(maker.maxAmount) > max_amount || parseFloat(maker.maxAmount) < min_amount)
+      const minAmount = parseFloat(Number(limits.list[newCurrency].min_amount).toPrecision(2));
+      const maxAmount = parseFloat(Number(limits.list[newCurrency].max_amount).toPrecision(2));
+      if (parseFloat(maker.minAmount) < minAmount || parseFloat(maker.minAmount) > maxAmount
+      || parseFloat(maker.maxAmount) > maxAmount || parseFloat(maker.maxAmount) < minAmount)
       {
         setMaker({
           ...maker,
-          minAmount: parseFloat(Number(limits.list[newCurrency].max_amount * 0.25).toPrecision(2)),
-          maxAmount: parseFloat(Number(limits.list[newCurrency].max_amount * 0.75).toPrecision(2)),
+          minAmount: (maxAmount * 0.25).toPrecision(2),
+          maxAmount: (maxAmount * 0.75).toPrecision(2),
         });
       };
     }


### PR DESCRIPTION
Currently when changing the currency in the advanced maker form the previously set amount range is discarded and reset to the standard values. This is pretty annoying when the user sets the amount range first and then changes the currency. 
This PR changes the handleCurrencyChange function to only reset the amount range if the current values are out of range of the newly selected currency and not unnecessarily reset it on every currency change.

Tested with the local docker env, seemed to work as supposed.