### PR TITLE
Add object limit to /api/ticks

### DIFF
--- a/api/oas_schemas.py
+++ b/api/oas_schemas.py
@@ -869,6 +869,31 @@ class TickViewSchema:
         "description": "Get all market ticks. Returns a list of all the market ticks since inception.\n"
         "CEX price is also recorded for useful insight on the historical premium of Non-KYC BTC. "
         "Price is set when taker bond is locked.",
+        "parameters": [
+            OpenApiParameter(
+                name="start",
+                location=OpenApiParameter.QUERY,
+                description="Start date formatted as DD-MM-YYYY",
+                required=False,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="end",
+                location=OpenApiParameter.QUERY,
+                description="End date formatted as DD-MM-YYYY",
+                required=False,
+                type=str,
+            ),
+        ],
+        "examples": [
+            OpenApiExample(
+                "Too many ticks",
+                value={
+                    "bad_request": "More than 5000 market ticks have been found. Try narrowing the date range."
+                },
+                status_codes=[400],
+            )
+        ],
     }
 
 


### PR DESCRIPTION
## What does this PR do?
Fixes too many objects in responses from `/api/ticks` leading to a 502 error.

This PR introduces two new GET parameters for the `TicksView`: `start` and `end` that can be used to subset the number of objects the response will contain. If the query has more than 5000 object, a 400 error will be thrown.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.