### PR TITLE
Fix book header labels

### DIFF
--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -40,6 +40,26 @@ const ClickThroughDataGrid = styled(DataGrid)({
   '& .MuiDataGrid-overlayWrapperInner': {
     pointerEvents: 'none',
   },
+  // Temporary fix for regression for hidden column labels on Mobile:
+  // https://github.com/mui/mui-x/issues/9776#issuecomment-1648306844
+  '@media (hover: none)': {
+    '&& .MuiDataGrid-menuIcon': {
+      width: 0,
+      visibility: 'hidden',
+    },
+    '&& .MuiDataGrid-sortIcon': {
+      width: 0,
+      visibility: 'hidden',
+    },
+  },
+  '&& .MuiDataGrid-columnHeader--sorted .MuiDataGrid-menuIcon': {
+    width: 'auto',
+    visibility: 'visible',
+  },
+  '&& .MuiDataGrid-columnHeader--sorted .MuiDataGrid-sortIcon': {
+    width: 'auto',
+    visibility: 'visible',
+  },
 });
 
 const premiumColor = function (baseColor: string, accentColor: string, point: number) {


### PR DESCRIPTION
## What does this PR do?
Recent MUI-X version makes Mobile header labels hide since the Sort and Menu column buttons are always visible. This PR introduces a temporary CSS fix based on https://github.com/mui/mui-x/issues/9776

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.