### PR TITLE
Use amboss.space onion link in Stats

### DIFF
--- a/frontend/src/components/Dialogs/Stats.tsx
+++ b/frontend/src/components/Dialogs/Stats.tsx
@@ -36,6 +36,12 @@ interface Props {
 const StatsDialog = ({ open = false, onClose, info }: Props): JSX.Element => {
   const { t } = useTranslation();
 
+  const isOnionAccess = window.location.hostname.endsWith('.onion');
+
+  const ambossURL = isOnionAccess
+    ? `http://amboss5jfdzzblty5dr5zaig5twvkgsla6y5xuy6s5c5ogpjfcqgltid.onion/node/${info.node_id}`
+    : `https://amboss.space/node/${info.node_id}`;
+
   return (
     <Dialog open={open} onClose={onClose}>
       <div style={info.loading ? {} : { display: 'none' }}>
@@ -107,11 +113,7 @@ const StatsDialog = ({ open = false, onClose, info }: Props): JSX.Element => {
                 <AmbossIcon />
               </ListItemIcon>
               <ListItemText secondary={info.node_alias}>
-                <Link
-                  target='_blank'
-                  href={`https://amboss.space/node/${info.node_id}`}
-                  rel='noreferrer'
-                >
+                <Link target='_blank' href={ambossURL} rel='noreferrer'>
                   {`${info.node_id.slice(0, 12)}... (AMBOSS)`}
                 </Link>
               </ListItemText>


### PR DESCRIPTION
## What does this PR do?
Fixes #841 

This PR introduces/refactors/...
Checks if Robosats is accessed via onion link via window.location.hostname.endsWith, if yes the user will be redirected to the amboss.space onion link when clicking on the robosats node in the Stats dialog. Otherwise the clearnet amboss.space will be used like before.

## Checklist before merging
Used .editorconf, and pre-commit to check it. Checked the changes with the frontend docker setup and a hidden service, worked as supposed for localhost and the onion link. Maybe need some additional check for the android app?