### PR TITLE
Update base image to python 3.12 bookworm

### DIFF
--- a/.github/workflows/django-test.yml
+++ b/.github/workflows/django-test.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.11.6"] # , "3.12"]
+        python-version: ["3.11.6", "3.12"]
 
     services:
       db:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.6-slim-bookworm
+FROM python:3.12.0-slim-bookworm
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN mkdir -p /usr/src/robosats


### PR DESCRIPTION
## What does this PR do?
Update dependencies and base image to python 3.12-slim-bookworm. It seems this build has some minor stability issues so I will not merge until further tested.

Update to Robohash https://github.com/RoboSats/Robohash/commit/d0614c160acfec198d2edbf277e7e839467db823 was needed as well.

This PR introduces/refactors/...

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.