### PR TITLE
Change getRobot by getSlot

### DIFF
--- a/frontend/src/basic/BookPage/index.tsx
+++ b/frontend/src/basic/BookPage/index.tsx
@@ -31,7 +31,7 @@ const BookPage = (): JSX.Element => {
   const chartWidthEm = width - maxBookTableWidth;
 
   const onOrderClicked = function (id: number, shortAlias: string): void {
-    if (garage.getRobot().avatarLoaded) {
+    if (garage.getSlot().robot.avatarLoaded) {
       setDelay(10000);
       navigate(`/order/${shortAlias}/${id}`);
     } else {

--- a/frontend/src/basic/Main.tsx
+++ b/frontend/src/basic/Main.tsx
@@ -44,7 +44,7 @@ const Main: React.FC = () => {
     <Router>
       <RobotAvatar
         style={{ display: 'none' }}
-        nickname={garage.getRobot().nickname}
+        nickname={garage.getSlot().robot.nickname}
         baseUrl={federation.getCoordinator(sortedCoordinators[0]).getBaseUrl()}
         onLoad={() => {
           garage.updateRobot({ avatarLoaded: true });
@@ -55,7 +55,7 @@ const Main: React.FC = () => {
         openProfile={() => {
           setOpen({ ...closeAll, profile: true });
         }}
-        rewards={garage.getRobot().earnedRewards}
+        rewards={garage.getSlot().robot.earnedRewards}
         windowWidth={windowSize?.width}
       />
       {settings.network === 'testnet' ? (

--- a/frontend/src/basic/MakerPage/index.tsx
+++ b/frontend/src/basic/MakerPage/index.tsx
@@ -51,7 +51,7 @@ const MakerPage = (): JSX.Element => {
   ]);
 
   const onOrderClicked = function (id: number): void {
-    if (garage.getRobot().avatarLoaded) {
+    if (garage.getSlot().robot.avatarLoaded) {
       navigate(`/order/${id}`);
     } else {
       setOpenNoRobot(true);

--- a/frontend/src/basic/NavBar/NavBar.tsx
+++ b/frontend/src/basic/NavBar/NavBar.tsx
@@ -42,7 +42,7 @@ const NavBar = (): JSX.Element => {
   const tabSx = smallBar
     ? {
         position: 'relative',
-        bottom: garage.getRobot().avatarLoaded ? '0.9em' : '0.13em',
+        bottom: garage.getSlot().robot.avatarLoaded ? '0.9em' : '0.13em',
         minWidth: '1em',
       }
     : { position: 'relative', bottom: '1em', minWidth: '2em' };
@@ -118,16 +118,16 @@ const NavBar = (): JSX.Element => {
         <Tab
           sx={{ ...tabSx, minWidth: '2.5em', width: '2.5em', maxWidth: '4em' }}
           value='none'
-          disabled={garage.getRobot().nickname === null}
+          disabled={garage.getSlot().robot.nickname === null}
           onClick={() => {
             setOpen({ ...closeAll, profile: !open.profile });
           }}
           icon={
-            garage.getRobot().nickname != null && garage.getRobot().avatarLoaded ? (
+            garage.getSlot().robot.nickname != null && garage.getSlot().robot.avatarLoaded ? (
               <RobotAvatar
                 style={{ width: '2.3em', height: '2.3em', position: 'relative', top: '0.2em' }}
                 avatarClass={theme.palette.mode === 'dark' ? 'navBarAvatarDark' : 'navBarAvatar'}
-                nickname={garage.getRobot().nickname}
+                nickname={garage.getSlot().robot.nickname}
                 baseUrl={hostUrl}
               />
             ) : (
@@ -162,7 +162,7 @@ const NavBar = (): JSX.Element => {
           sx={tabSx}
           label={smallBar ? undefined : t('Order')}
           value='order'
-          disabled={!garage.getRobot().avatarLoaded || !garage.getSlot().activeOrderId}
+          disabled={!garage.getSlot().robot.avatarLoaded || !garage.getSlot().activeOrderId}
           icon={<Assignment />}
           iconPosition='start'
         />

--- a/frontend/src/basic/OrderPage/index.tsx
+++ b/frontend/src/basic/OrderPage/index.tsx
@@ -45,7 +45,7 @@ const OrderPage = (): JSX.Element => {
         setCurrentOrder(garage.getSlot().order);
       } else {
         coordinator
-          .fetchOrder(Number(params.orderId) ?? null, garage.getRobot())
+          .fetchOrder(Number(params.orderId) ?? null, garage.getSlot().robot)
           .then((order) => {
             if (order?.bad_request !== undefined) {
               setBadOrder(order.bad_request);
@@ -60,7 +60,7 @@ const OrderPage = (): JSX.Element => {
       }
     } else {
       coordinator
-        .fetchOrder(Number(params.orderId) ?? null, garage.getRobot())
+        .fetchOrder(Number(params.orderId) ?? null, garage.getSlot().robot)
         .then((order) => {
           if (order?.bad_request !== undefined) {
             setBadOrder(order.bad_request);
@@ -107,7 +107,9 @@ const OrderPage = (): JSX.Element => {
         .getCoordinator(order.shortAlias)
         .getEndpoint(settings.network, origin, settings.selfhostedClient, hostUrl);
       apiClient
-        .post(url + basePath, '/api/make/', body, { tokenSHA256: garage.getRobot().tokenSHA256 })
+        .post(url + basePath, '/api/make/', body, {
+          tokenSHA256: garage.getSlot().robot.tokenSHA256,
+        })
         .then((data: any) => {
           if (data.bad_request !== undefined) {
             setBadOrder(data.bad_request);
@@ -175,7 +177,7 @@ const OrderPage = (): JSX.Element => {
                   }}
                 >
                   <TradeBox
-                    robot={garage.getRobot()}
+                    robot={garage.getSlot().robot}
                     currentOrder={currentOrder}
                     settings={settings}
                     setBadOrder={setBadOrder}
@@ -222,7 +224,7 @@ const OrderPage = (): JSX.Element => {
                 </div>
                 <div style={{ display: tab === 'contract' ? '' : 'none' }}>
                   <TradeBox
-                    robot={garage.getRobot()}
+                    robot={garage.getSlot().robot}
                     currentOrder={currentOrder}
                     settings={settings}
                     setBadOrder={setBadOrder}

--- a/frontend/src/basic/RobotPage/Onboarding.tsx
+++ b/frontend/src/basic/RobotPage/Onboarding.tsx
@@ -149,7 +149,7 @@ const Onboarding = ({
           <Grid container direction='column' alignItems='center' spacing={1}>
             <Grid item>
               <Typography>
-                {garage.getRobot().avatarLoaded && Boolean(garage.getRobot().nickname) ? (
+                {garage.getSlot().robot.avatarLoaded && Boolean(garage.getSlot().robot.nickname) ? (
                   t('This is your trading avatar')
                 ) : (
                   <>
@@ -162,7 +162,7 @@ const Onboarding = ({
 
             <Grid item sx={{ width: '13.5em' }}>
               <RobotAvatar
-                nickname={garage.getRobot().nickname}
+                nickname={garage.getSlot().robot.nickname}
                 smooth={true}
                 style={{ maxWidth: '12.5em', maxHeight: '12.5em' }}
                 placeholderType='generating'
@@ -178,7 +178,7 @@ const Onboarding = ({
               />
             </Grid>
 
-            {garage.getRobot().avatarLoaded && Boolean(garage.getRobot().nickname) ? (
+            {garage.getSlot().robot.avatarLoaded && Boolean(garage.getSlot().robot.nickname) ? (
               <Grid item>
                 <Typography align='center'>{t('Hi! My name is')}</Typography>
                 <Typography component='h5' variant='h5'>
@@ -197,7 +197,7 @@ const Onboarding = ({
                         width: '1.5em',
                       }}
                     />
-                    <b>{garage.getRobot().nickname}</b>
+                    <b>{garage.getSlot().robot.nickname}</b>
                     <Bolt
                       sx={{
                         color: '#fcba03',
@@ -211,7 +211,11 @@ const Onboarding = ({
             ) : null}
             <Grid item>
               <Collapse
-                in={!!(garage.getRobot().avatarLoaded && Boolean(garage.getRobot().nickname))}
+                in={
+                  !!(
+                    garage.getSlot().robot.avatarLoaded && Boolean(garage.getSlot().robot.nickname)
+                  )
+                }
               >
                 <Button
                   onClick={() => {

--- a/frontend/src/basic/RobotPage/RobotProfile.tsx
+++ b/frontend/src/basic/RobotPage/RobotProfile.tsx
@@ -53,7 +53,7 @@ const RobotProfile = ({
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    if (garage.getRobot().nickname != null && garage.getRobot().avatarLoaded) {
+    if (garage.getSlot().robot.nickname != null && garage.getSlot().robot.avatarLoaded) {
       setLoading(false);
     }
   }, [robotUpdatedAt, loading]);
@@ -79,7 +79,7 @@ const RobotProfile = ({
         sx={{ width: '100%' }}
       >
         <Grid item sx={{ height: '2.3em', position: 'relative' }}>
-          {garage.getRobot().avatarLoaded && garage.getRobot().nickname != null ? (
+          {garage.getSlot().robot.avatarLoaded && garage.getSlot().robot.nickname != null ? (
             <Typography align='center' component='h5' variant='h5'>
               <div
                 style={{
@@ -98,7 +98,7 @@ const RobotProfile = ({
                     }}
                   />
                 )}
-                <b>{garage.getRobot().nickname}</b>
+                <b>{garage.getSlot().robot.nickname}</b>
                 {width < 19 ? null : (
                   <Bolt
                     sx={{
@@ -120,7 +120,7 @@ const RobotProfile = ({
 
         <Grid item sx={{ width: `13.5em` }}>
           <RobotAvatar
-            nickname={garage.getRobot().nickname}
+            nickname={garage.getSlot().robot.nickname}
             smooth={true}
             style={{ maxWidth: '12.5em', maxHeight: '12.5em' }}
             placeholderType='generating'
@@ -135,7 +135,7 @@ const RobotProfile = ({
             tooltipPosition='top'
             baseUrl={hostUrl}
           />
-          {garage.getRobot().found && Number(garage.getRobot().lastOrderId) > 0 ? (
+          {garage.getSlot().robot.found && Number(garage.getSlot().lastOrderId) > 0 ? (
             <Typography align='center' variant='h6'>
               {t('Welcome back!')}
             </Typography>
@@ -145,8 +145,8 @@ const RobotProfile = ({
         </Grid>
 
         {Boolean(garage.getSlot().activeOrderId) &&
-        garage.getRobot().avatarLoaded &&
-        Boolean(garage.getRobot().nickname) ? (
+        garage.getSlot().robot.avatarLoaded &&
+        Boolean(garage.getSlot().robot.nickname) ? (
           <Grid item>
             <Button
               onClick={() => {
@@ -163,8 +163,8 @@ const RobotProfile = ({
         ) : null}
 
         {Boolean(garage.getSlot().lastOrderId) &&
-        garage.getRobot().avatarLoaded &&
-        Boolean(garage.getRobot().nickname) ? (
+        garage.getSlot().robot.avatarLoaded &&
+        Boolean(garage.getSlot().robot.nickname) ? (
           <Grid item container direction='column' alignItems='center'>
             <Grid item>
               <Button

--- a/frontend/src/basic/RobotPage/TokenInput.tsx
+++ b/frontend/src/basic/RobotPage/TokenInput.tsx
@@ -67,7 +67,7 @@ const TokenInput = ({
             <Tooltip open={showCopied} title={t('Copied!')}>
               <IconButton
                 autoFocus={autoFocusTarget === 'copyButton'}
-                color={garage.getRobot().copiedToken ? 'inherit' : 'primary'}
+                color={garage.getSlot().robot.copiedToken ? 'inherit' : 'primary'}
                 onClick={() => {
                   systemClient.copyToClipboard(inputToken);
                   setShowCopied(true);

--- a/frontend/src/basic/RobotPage/index.tsx
+++ b/frontend/src/basic/RobotPage/index.tsx
@@ -41,11 +41,11 @@ const RobotPage = ({ avatarBaseUrl }: RobotPageProps): JSX.Element => {
   const [badToken, setBadToken] = useState<string>('');
   const [inputToken, setInputToken] = useState<string>('');
   const [view, setView] = useState<'welcome' | 'onboarding' | 'recovery' | 'profile'>(
-    garage.getRobot().token !== undefined ? 'profile' : 'welcome',
+    garage.getSlot().robot.token !== undefined ? 'profile' : 'welcome',
   );
 
   useEffect(() => {
-    const token = urlToken ?? garage.getRobot().token;
+    const token = urlToken ?? garage.getSlot().robot.token;
     if (token !== undefined) {
       setInputToken(token);
       if (window.NativeRobosats === undefined || torStatus === '"Done"') {

--- a/frontend/src/components/Dialogs/Profile.tsx
+++ b/frontend/src/components/Dialogs/Profile.tsx
@@ -33,7 +33,7 @@ const ProfileDialog = ({ open = false, baseUrl, onClose }: Props): JSX.Element =
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    setLoading(garage.getRobot().loading);
+    setLoading(garage.getSlot().robot.loading);
   }, [robotUpdatedAt]);
 
   return (
@@ -57,7 +57,7 @@ const ProfileDialog = ({ open = false, baseUrl, onClose }: Props): JSX.Element =
           <ListItem className='profileNickname'>
             <ListItemText secondary={t('Your robot')}>
               <Typography component='h6' variant='h6'>
-                {garage.getRobot().nickname !== undefined && (
+                {garage.getSlot().robot.nickname !== undefined && (
                   <div style={{ position: 'relative', left: '-7px' }}>
                     <div
                       style={{
@@ -70,7 +70,7 @@ const ProfileDialog = ({ open = false, baseUrl, onClose }: Props): JSX.Element =
                     >
                       <BoltIcon sx={{ color: '#fcba03', height: '28px', width: '24px' }} />
 
-                      <a>{garage.getRobot().nickname}</a>
+                      <a>{garage.getSlot().robot.nickname}</a>
 
                       <BoltIcon sx={{ color: '#fcba03', height: '28px', width: '24px' }} />
                     </div>
@@ -83,7 +83,7 @@ const ProfileDialog = ({ open = false, baseUrl, onClose }: Props): JSX.Element =
               <RobotAvatar
                 avatarClass='profileAvatar'
                 style={{ width: 65, height: 65 }}
-                nickname={garage.getRobot().nickname}
+                nickname={garage.getSlot().robot.nickname}
                 baseUrl={baseUrl}
               />
             </ListItemAvatar>
@@ -97,12 +97,12 @@ const ProfileDialog = ({ open = false, baseUrl, onClose }: Props): JSX.Element =
         </Typography>
 
         {Object.values(federation.coordinators).map((coordinator: Coordinator): JSX.Element => {
-          if (!garage.getRobot()?.loading) {
+          if (!garage.getSlot().robot?.loading) {
             return (
               <div key={coordinator.shortAlias}>
                 <RobotInfo
                   coordinator={coordinator}
-                  robot={garage.getRobot()}
+                  robot={garage.getSlot().robot}
                   slotIndex={garage.currentSlot}
                   onClose={onClose}
                 />

--- a/frontend/src/components/Dialogs/StoreToken.tsx
+++ b/frontend/src/components/Dialogs/StoreToken.tsx
@@ -43,7 +43,7 @@ const StoreTokenDialog = ({ open, onClose, onClickBack, onClickDone }: Props): J
             sx={{ width: '100%', maxWidth: '550px' }}
             disabled
             label={t('Back it up!')}
-            value={garage.getRobot().token}
+            value={garage.getSlot().robot.token}
             variant='filled'
             size='small'
             InputProps={{
@@ -51,7 +51,7 @@ const StoreTokenDialog = ({ open, onClose, onClickBack, onClickDone }: Props): J
                 <Tooltip disableHoverListener enterTouchDelay={0} title={t('Copied!')}>
                   <IconButton
                     onClick={() => {
-                      systemClient.copyToClipboard(garage.getRobot().token);
+                      systemClient.copyToClipboard(garage.getSlot().robot.token);
                     }}
                   >
                     <ContentCopy color='primary' />

--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -286,10 +286,10 @@ const MakerForm = ({
         ?.getEndpoint(settings.network, origin, settings.selfhostedClient, hostUrl) ?? {};
 
     const auth = {
-      tokenSHA256: garage.getRobot().tokenSHA256,
+      tokenSHA256: garage.getSlot().robot.tokenSHA256,
       keys: {
-        pubKey: garage.getRobot().pubKey?.split('\n').join('\\'),
-        encPrivKey: garage.getRobot().encPrivKey?.split('\n').join('\\'),
+        pubKey: garage.getSlot().robot.pubKey?.split('\n').join('\\'),
+        encPrivKey: garage.getSlot().robot.encPrivKey?.split('\n').join('\\'),
       },
     };
 
@@ -570,7 +570,7 @@ const MakerForm = ({
           setOpenDialogs(false);
         }}
         onClickDone={handleCreateOrder}
-        hasRobot={garage.getRobot().avatarLoaded}
+        hasRobot={garage.getSlot().robot.avatarLoaded}
         onClickGenerateRobot={onClickGenerateRobot}
       />
       <F2fMapDialog

--- a/frontend/src/components/OrderDetails/TakeButton.tsx
+++ b/frontend/src/components/OrderDetails/TakeButton.tsx
@@ -328,7 +328,7 @@ const TakeButton = ({
           action: 'take',
           amount: currentOrder?.currency === 1000 ? takeAmount / 100000000 : takeAmount,
         },
-        { tokenSHA256: garage.getRobot().tokenSHA256 },
+        { tokenSHA256: garage.getSlot().robot.tokenSHA256 },
       )
       .then((data) => {
         setLoadingTake(false);
@@ -370,7 +370,7 @@ const TakeButton = ({
           setLoadingTake(true);
           setOpen(closeAll);
         }}
-        hasRobot={garage.getRobot().avatarLoaded}
+        hasRobot={garage.getSlot().robot.avatarLoaded}
         onClickGenerateRobot={onClickGenerateRobot}
       />
       <InactiveMakerDialog />

--- a/frontend/src/components/RobotInfo/index.tsx
+++ b/frontend/src/components/RobotInfo/index.tsx
@@ -85,7 +85,7 @@ const RobotInfo: React.FC<Props> = ({ robot, slotIndex, coordinator, onClose }: 
     setBadInvoice('');
     setShowRewardsSpinner(true);
 
-    const robot = garage.getRobot(slotIndex);
+    const robot = garage.getSlot(slotIndex).robot;
 
     if (robot.encPrivKey != null && robot.token != null) {
       void signCleartextMessage(rewardInvoice, robot.encPrivKey, robot.token).then(
@@ -110,21 +110,22 @@ const RobotInfo: React.FC<Props> = ({ robot, slotIndex, coordinator, onClose }: 
     <Accordion>
       <AccordionSummary expandIcon={<ExpandMore />}>
         {`${coordinator.longAlias}:`}
-        {garage.getRobot(slotIndex).earnedRewards > 0 && (
+        {garage.getSlot(slotIndex).robot.earnedRewards > 0 && (
           <Typography color='success'>&nbsp;{t('Claim Sats!')} </Typography>
         )}
-        {(garage.getRobot(slotIndex).activeOrderId ?? 0) > 0 && (
+        {(garage.getSlot(slotIndex).robot.activeOrderId ?? 0) > 0 && (
           <Typography color='success'>
             &nbsp;<b>{t('Active order!')}</b>
           </Typography>
         )}
-        {(garage.getRobot(slotIndex).lastOrderId ?? 0) > 0 && robot.activeOrderId === undefined && (
-          <Typography color='warning'>&nbsp;{t('finished order')}</Typography>
-        )}
+        {(garage.getSlot(slotIndex).robot.lastOrderId ?? 0) > 0 &&
+          robot.activeOrderId === undefined && (
+            <Typography color='warning'>&nbsp;{t('finished order')}</Typography>
+          )}
       </AccordionSummary>
       <AccordionDetails>
         <List dense disablePadding={true}>
-          {(garage.getRobot(slotIndex).activeOrderId ?? 0) > 0 ? (
+          {(garage.getSlot(slotIndex).robot.activeOrderId ?? 0) > 0 ? (
             <ListItemButton
               onClick={() => {
                 navigate(`/order/${coordinator.shortAlias}/${String(robot.activeOrderId)}`);
@@ -141,7 +142,7 @@ const RobotInfo: React.FC<Props> = ({ robot, slotIndex, coordinator, onClose }: 
                 secondary={t('Your current order')}
               />
             </ListItemButton>
-          ) : (garage.getRobot(slotIndex).lastOrderId ?? 0) > 0 ? (
+          ) : (garage.getSlot(slotIndex).robot.lastOrderId ?? 0) > 0 ? (
             <ListItemButton
               onClick={() => {
                 navigate(`/order/${coordinator.shortAlias}/${String(robot.lastOrderId)}`);

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -66,7 +66,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
   const [error, setError] = useState<string>('');
 
   useEffect(() => {
-    if (!connected && garage.getRobot().avatarLoaded) {
+    if (!connected && garage.getSlot().robot.avatarLoaded) {
       connectWebsocket();
     }
   }, [connected, robot]);

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -231,7 +231,7 @@ const TradeBox = ({
   };
 
   const updateInvoice = function (invoice: string): void {
-    const robot = garage.getRobot();
+    const robot = garage.getSlot().robot;
 
     if (robot?.encPrivKey != null && robot?.token != null) {
       setLoadingButtons({ ...noLoadingButtons, submitInvoice: true });
@@ -246,7 +246,7 @@ const TradeBox = ({
   };
 
   const updateAddress = function (): void {
-    const robot = garage.getRobot();
+    const robot = garage.getSlot().robot;
 
     if (robot?.encPrivKey != null && robot?.token != null) {
       setLoadingButtons({ ...noLoadingButtons, submitAddress: true });

--- a/frontend/src/contexts/FederationContext.ts
+++ b/frontend/src/contexts/FederationContext.ts
@@ -135,7 +135,7 @@ export const useFederationStore = (): UseFederationStoreType => {
   }, [delay, currentOrder, page, badOrder]);
 
   useEffect(() => {
-    const robot = garage.getRobot();
+    const robot = garage.getSlot().robot;
 
     if (robot !== null) {
       if (open.profile && robot?.avatarLoaded) {

--- a/frontend/src/models/Coordinator.model.ts
+++ b/frontend/src/models/Coordinator.model.ts
@@ -262,7 +262,7 @@ export class Coordinator {
   };
 
   fecthRobot = async (garage: Garage, index: number): Promise<Robot | null> => {
-    const robot = garage?.getRobot(index);
+    const robot = garage?.getSlot(index).robot;
 
     if (robot?.token == null) return null;
 
@@ -309,7 +309,7 @@ export class Coordinator {
       index,
     );
 
-    return garage.getRobot(index);
+    return garage.getSlot(index).robot;
   };
 
   fetchOrder = async (orderId: number, robot: Robot): Promise<Order | null> => {
@@ -343,7 +343,7 @@ export class Coordinator {
     bad_invoice?: string;
     successful_withdrawal?: boolean;
   }> => {
-    const robot = garage.getRobot(index);
+    const robot = garage.getSlot(index).robot;
 
     if (!(robot?.token != null) || !(robot.encPrivKey != null)) return null;
 
@@ -365,7 +365,7 @@ export class Coordinator {
   };
 
   fetchStealth = async (wantsStealth: boolean, garage: Garage, index: number): Promise<null> => {
-    const robot = garage?.getRobot(index);
+    const robot = garage?.getSlot(index).robot;
 
     if (!(robot?.token != null) || !(robot.encPrivKey != null)) return null;
 

--- a/frontend/src/models/Federation.model.ts
+++ b/frontend/src/models/Federation.model.ts
@@ -100,7 +100,7 @@ export class Federation {
     if (order.shortAlias !== null) {
       const coordinator = this.coordinators[order.shortAlias];
       if (coordinator != null && order.id !== null) {
-        const newOrder = await coordinator.fetchOrder(order.id, garage.getRobot());
+        const newOrder = await coordinator.fetchOrder(order.id, garage.getSlot().robot);
         if (newOrder != null) {
           garage.updateOrder(newOrder);
           return newOrder;

--- a/frontend/src/models/Garage.model.ts
+++ b/frontend/src/models/Garage.model.ts
@@ -113,7 +113,7 @@ class Garage {
     const robot = this.getSlot(index).robot;
     if (robot != null) {
       robot.update(attributes);
-      if (attributes.lastOrderId && attributes.lastOrderId != null) {
+      if (attributes.lastOrderId !== undefined && attributes.lastOrderId != null) {
         this.slots[index].lastOrderId = attributes.lastOrderId;
         this.slots[index].lastOrderShortAlias = attributes.shortAlias;
         if (attributes.lastOrderId === this.slots[index].activeOrderId) {
@@ -121,7 +121,7 @@ class Garage {
           this.slots[index].activeOrderShortAlias = null;
         }
       }
-      if (attributes.activeOrderId && attributes.activeOrderId != null) {
+      if (attributes.activeOrderId !== undefined && attributes.activeOrderId != null) {
         this.slots[index].activeOrderId = attributes.activeOrderId;
         this.slots[index].activeOrderShortAlias = attributes.shortAlias;
         this.slots[index].lastOrderId = null;
@@ -130,10 +130,6 @@ class Garage {
       this.triggerHook('onRobotUpdate');
       this.save();
     }
-  };
-
-  getRobot = (slot: number = this.currentSlot): Robot => {
-    return this.getSlot(slot).robot;
   };
 
   createRobot = (attributes: Record<any, any>): void => {


### PR DESCRIPTION
## What does this PR do?
There is a big difference between:
- `garage.getRobot().active_order_id`: order id of the last coordinator in return robot information
- `garage.getSlot().ActiveOrderId`: order id of an active order in one of the coordinators

I just removed the possibility to directly access to the robot through the garage and force to always land first into the slot  (`garage.getSlot().robot.found`) so it's clear where the aggregated information is (`garage.getSlot().ActiveOrderId`).

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.