### PR TITLE
fix: kycnot.me url

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Check out the [Developer Rewards Panel](https://github.com/users/Reckless-Satosh
 ## Reviews
 - **[Athena Alpha](https://www.athena-alpha.com/robosats-review/)**
 - **[Bitcoin Magazine](https://bitcoinmagazine.com/business/robosats-private-bitcoin-exchange)**
-- **[KYC? Not Me!](https://kycnot.me/exchange/robosats)**
+- **[KYC? Not Me!](https://kycnot.me/service/robosats)**
 - **[H17N Bitcoin](https://h17n.com/exchange/robosats/)**
 
 ## Inspiration


### PR DESCRIPTION
This PR fix kycnot.me url review

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.