### PR TITLE
Revert "Bump django from 4.2.7 to 5.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==5.0
+django==4.2.7
 django-admin-relation-links==0.2.5
 django-celery-beat==2.5.0
 django-celery-results==2.5.1


### PR DESCRIPTION
Reverts RoboSats/robosats#994

Reverting as tests with Django 5.0 were passing only because pip dependencies were cached. django-celery-beat is still incompatible with 5.0