### PR TITLE
fix: Remove linting errors on frontend

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,8 +7,8 @@
     "dev": "node --max-old-space-size=4096 ./node_modules/.bin/webpack --watch --progress --mode development",
     "test": "jest",
     "build": "webpack --mode production",
-    "lint": "eslint src/**/*.{js,ts,tsx}",
-    "lint:fix": "eslint --fix 'src/**/*.{js,ts,tsx}'",
+    "lint": "eslint src/**/*.{ts,tsx}",
+    "lint:fix": "eslint --fix 'src/**/*.{ts,tsx}'",
     "format": "prettier --write '**/**/*.{js,jsx,ts,tsx,css,md,json}' --config ./.prettierrc"
   },
   "keywords": [],

--- a/frontend/src/basic/Main.tsx
+++ b/frontend/src/basic/Main.tsx
@@ -87,7 +87,7 @@ const Main: React.FC = () => {
                   <Slide
                     direction={page === 'robot' ? slideDirection.in : slideDirection.out}
                     in={page === 'robot'}
-                    appear={slideDirection.in != undefined}
+                    appear={slideDirection.in !== undefined}
                   >
                     <div>
                       <RobotPage />
@@ -105,7 +105,7 @@ const Main: React.FC = () => {
               <Slide
                 direction={page === 'offers' ? slideDirection.in : slideDirection.out}
                 in={page === 'offers'}
-                appear={slideDirection.in != undefined}
+                appear={slideDirection.in !== undefined}
               >
                 <div>
                   <BookPage />
@@ -120,7 +120,7 @@ const Main: React.FC = () => {
               <Slide
                 direction={page === 'create' ? slideDirection.in : slideDirection.out}
                 in={page === 'create'}
-                appear={slideDirection.in != undefined}
+                appear={slideDirection.in !== undefined}
               >
                 <div>
                   <MakerPage />
@@ -135,7 +135,7 @@ const Main: React.FC = () => {
               <Slide
                 direction={page === 'order' ? slideDirection.in : slideDirection.out}
                 in={page === 'order'}
-                appear={slideDirection.in != undefined}
+                appear={slideDirection.in !== undefined}
               >
                 <div>
                   <OrderPage />
@@ -150,7 +150,7 @@ const Main: React.FC = () => {
               <Slide
                 direction={page === 'settings' ? slideDirection.in : slideDirection.out}
                 in={page === 'settings'}
-                appear={slideDirection.in != undefined}
+                appear={slideDirection.in !== undefined}
               >
                 <div>
                   <SettingsPage />

--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -343,8 +343,8 @@ const DepthChart: React.FC<DepthChartProps> = ({
                         ? 2.7 * em
                         : 1.78 * em
                       : width < 25
-                      ? 2.7 * em
-                      : 1.78 * em,
+                        ? 2.7 * em
+                        : 1.78 * em,
                   top: 0.714 * em,
                 }}
                 xFormat={(value) => Number(value).toFixed(0)}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -30,7 +30,7 @@ export default class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBo
     }, 30000);
   }
 
-  render() {
+  render(): React.ReactNode {
     if (this.state.hasError) {
       return (
         <div style={{ overflow: 'auto', height: '100%', width: '100%', background: 'white' }}>

--- a/frontend/src/components/MakerForm/AutocompletePayments.tsx
+++ b/frontend/src/components/MakerForm/AutocompletePayments.tsx
@@ -56,8 +56,8 @@ const InputWrapper = styled('div')(
           ? '#f44336'
           : sx.hoverBorderColor
         : error
-        ? '#dd0000'
-        : '#2f2f2f'
+          ? '#dd0000'
+          : '#2f2f2f'
     };
   }
 
@@ -68,8 +68,8 @@ const InputWrapper = styled('div')(
           ? '#f44336'
           : '#90caf9'
         : error
-        ? '#dd0000'
-        : '#1976d2'
+          ? '#dd0000'
+          : '#1976d2'
     };
   }
 

--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -495,12 +495,12 @@ const MakerForm = ({
             ? t('Order for ')
             : t('Swap of ')
           : fav.type == 1
-          ? fav.mode === 'fiat'
-            ? t('Buy BTC for ')
-            : t('Swap into LN ')
-          : fav.mode === 'fiat'
-          ? t('Sell BTC for ')
-          : t('Swap out of LN ')}
+            ? fav.mode === 'fiat'
+              ? t('Buy BTC for ')
+              : t('Swap into LN ')
+            : fav.mode === 'fiat'
+              ? t('Sell BTC for ')
+              : t('Swap out of LN ')}
         {fav.mode === 'fiat'
           ? amountToString(maker.amount, makerHasAmountRange, maker.minAmount, maker.maxAmount)
           : amountToString(
@@ -513,12 +513,12 @@ const MakerForm = ({
         {maker.isExplicit
           ? t(' of {{satoshis}} Satoshis', { satoshis: pn(maker.satoshis) })
           : maker.premium == 0
-          ? fav.mode === 'fiat'
-            ? t(' at market price')
-            : ''
-          : maker.premium > 0
-          ? t(' at a {{premium}}% premium', { premium: maker.premium })
-          : t(' at a {{discount}}% discount', { discount: -maker.premium })}
+            ? fav.mode === 'fiat'
+              ? t(' at market price')
+              : ''
+            : maker.premium > 0
+              ? t(' at a {{premium}}% premium', { premium: maker.premium })
+              : t(' at a {{discount}}% discount', { discount: -maker.premium })}
       </Typography>
     );
   };
@@ -739,10 +739,10 @@ const MakerForm = ({
                                 minAmount: pn(parseFloat(amountLimits[0].toPrecision(2))),
                               })
                             : maker.amount > amountLimits[1] && maker.amount != ''
-                            ? t('Must be less than {{maxAmount}}', {
-                                maxAmount: pn(parseFloat(amountLimits[1].toPrecision(2))),
-                              })
-                            : null
+                              ? t('Must be less than {{maxAmount}}', {
+                                  maxAmount: pn(parseFloat(amountLimits[1].toPrecision(2))),
+                                })
+                              : null
                         }
                         label={amountLabel.label}
                         required={true}

--- a/frontend/src/models/Garage.model.ts
+++ b/frontend/src/models/Garage.model.ts
@@ -11,7 +11,7 @@ const emptySlot: Slot = { robot: new Robot(), order: null };
 class Garage {
   constructor(initialState?: Garage) {
     const slotsDump: string = systemClient.getItem('garage');
-    if (initialState?.slots === undefined && slotsDump != '') {
+    if (initialState?.slots === undefined && slotsDump !== '') {
       this.slots = JSON.parse(slotsDump);
       console.log('Robot Garage was loaded from local storage');
     } else {
@@ -21,11 +21,11 @@ class Garage {
 
   slots: Slot[] = [emptySlot];
 
-  save = () => {
+  save = (): void => {
     systemClient.setItem('garage', JSON.stringify(this.slots));
   };
 
-  delete = () => {
+  delete = (): void => {
     this.slots = [emptySlot];
     systemClient.deleteItem('garage');
   };
@@ -35,7 +35,7 @@ class Garage {
     this.save();
   };
 
-  download = () => {
+  download = (): void => {
     saveAsJson(`robotGarage_${new Date().toISOString()}.json`, this.slots);
   };
 

--- a/frontend/src/models/Settings.model.ts
+++ b/frontend/src/models/Settings.model.ts
@@ -28,9 +28,9 @@ class BaseSettings {
     this.mode =
       modeCookie !== ''
         ? modeCookie
-        : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
-        ? 'dark'
-        : 'light';
+        : window.matchMedia?.('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
 
     this.lightQRs = systemClient.getItem('settings_light_qr') === 'true';
 
@@ -39,8 +39,8 @@ class BaseSettings {
       languageCookie !== ''
         ? languageCookie
         : i18n.resolvedLanguage == null
-        ? 'en'
-        : i18n.resolvedLanguage.substring(0, 2);
+          ? 'en'
+          : i18n.resolvedLanguage.substring(0, 2);
 
     const networkCookie = systemClient.getItem('settings_network');
     this.network = networkCookie !== '' ? networkCookie : 'mainnet';

--- a/frontend/src/pro/Main.tsx
+++ b/frontend/src/pro/Main.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import GridLayout, { type Layout } from 'react-grid-layout';
 import { Grid, styled, useTheme } from '@mui/material';
 
@@ -23,9 +23,9 @@ import { AppContext, type UseAppStoreType } from '../contexts/AppContext';
 
 const StyledRGL = styled(GridLayout)(
   ({ theme, gridCellSize, height, width, freeze }) => `
-  height: ${height}em;
-  width: ${width}px;
-  max-height: ${height}em;
+  height: ${height as number}em;
+  width: ${width as number}px;
+  max-height: ${height as number}em;
   `,
 );
 
@@ -41,35 +41,7 @@ const defaultLayout: Layout = [
 ];
 
 const Main = (): JSX.Element => {
-  const {
-    book,
-    fetchBook,
-    maker,
-    setMaker,
-    setSettings,
-    clearOrder,
-    torStatus,
-    settings,
-    limits,
-    fetchLimits,
-    robot,
-    setRobot,
-    fetchRobot,
-    setOrder,
-    setDelay,
-    info,
-    fav,
-    setFav,
-    baseUrl,
-    order,
-    currentOrder,
-    setCurrentOrder,
-    open,
-    setOpen,
-    windowSize,
-    badOrder,
-    setBadOrder,
-  } = useContext<UseAppStoreType>(AppContext);
+  const { setSettings, settings, windowSize } = useContext<UseAppStoreType>(AppContext);
 
   const theme = useTheme();
   const em: number = theme.typography.fontSize;
@@ -80,7 +52,7 @@ const Main = (): JSX.Element => {
   const [layout, setLayout] = useState<Layout>(defaultLayout);
 
   return (
-    <Grid container direction='column' sx={{ width: `${windowSize.width}em` }}>
+    <Grid container direction='column' sx={{ width: `${windowSize.width as number}em` }}>
       <Grid item>
         <ToolBar height={`${toolbarHeight}em`} settings={settings} setSettings={setSettings} />
         <LandingDialog
@@ -96,14 +68,14 @@ const Main = (): JSX.Element => {
           height={windowSize.height - toolbarHeight}
           width={Number((windowSize.width / gridCellSize).toFixed()) * gridCellSize * em}
           theme={theme}
-          freeze={!settings.freezeViewports}
+          freeze={!(settings.freezeViewports as boolean)}
           gridCellSize={gridCellSize}
           className='layout'
           layout={layout}
           cols={Number((windowSize.width / gridCellSize).toFixed())} // cols are 2em wide
           margin={[0.5 * em, 0.5 * em]}
-          isDraggable={!settings.freezeViewports}
-          isResizable={!settings.freezeViewports}
+          isDraggable={!(settings.freezeViewports as boolean)}
+          isResizable={!(settings.freezeViewports as boolean)}
           rowHeight={gridCellSize * em} // rows are 2em high
           autoSize={true}
           onLayoutChange={(layout: Layout) => {

--- a/frontend/src/utils/filterOrders.ts
+++ b/frontend/src/utils/filterOrders.ts
@@ -15,7 +15,7 @@ interface FilterOrders {
   paymentMethods?: string[];
 }
 
-const filterByPayment = function (order: PublicOrder, paymentMethods: any[]) {
+const filterByPayment = function (order: PublicOrder, paymentMethods: any[]): boolean {
   if (paymentMethods.length === 0) {
     return true;
   } else {
@@ -27,11 +27,11 @@ const filterByPayment = function (order: PublicOrder, paymentMethods: any[]) {
   }
 };
 
-const filterByAmount = function (order: PublicOrder, filter: AmountFilter) {
+const filterByAmount = function (order: PublicOrder, filter: AmountFilter): boolean {
   const filterMaxAmount =
-    Number(filter.amount != '' ? filter.amount : filter.maxAmount) * (1 + filter.threshold);
+    Number(filter.amount !== '' ? filter.amount : filter.maxAmount) * (1 + filter.threshold);
   const filterMinAmount =
-    Number(filter.amount != '' ? filter.amount : filter.minAmount) * (1 - filter.threshold);
+    Number(filter.amount !== '' ? filter.amount : filter.minAmount) * (1 - filter.threshold);
 
   const orderMinAmount = Number(
     order.amount === '' || order.amount === null ? order.min_amount : order.amount,
@@ -43,8 +43,8 @@ const filterByAmount = function (order: PublicOrder, filter: AmountFilter) {
   return Math.max(filterMinAmount, orderMinAmount) <= Math.min(filterMaxAmount, orderMaxAmount);
 };
 
-const filterByPremium = function (order: PublicOrder, premium: number) {
-  if (order.type == 0) {
+const filterByPremium = function (order: PublicOrder, premium: number): boolean {
+  if (order.type === 0) {
     return order.premium >= premium;
   } else {
     return order.premium <= premium;
@@ -57,12 +57,12 @@ const filterOrders = function ({
   premium = null,
   paymentMethods = [],
   amountFilter = null,
-}: FilterOrders) {
+}: FilterOrders): PublicOrder[] {
   const filteredOrders = orders.filter((order) => {
-    const typeChecks = order.type == baseFilter.type || baseFilter.type == null;
+    const typeChecks = order.type === baseFilter.type || baseFilter.type === null;
     const modeChecks = baseFilter.mode === 'fiat' ? !(order.currency === 1000) : true;
     const premiumChecks = premium != null ? filterByPremium(order, premium) : true;
-    const currencyChecks = order.currency == baseFilter.currency || baseFilter.currency == 0;
+    const currencyChecks = order.currency === baseFilter.currency || baseFilter.currency === 0;
     const paymentMethodChecks =
       paymentMethods.length > 0 ? filterByPayment(order, paymentMethods) : true;
     const amountChecks = amountFilter != null ? filterByAmount(order, amountFilter) : true;

--- a/frontend/src/utils/getHost.ts
+++ b/frontend/src/utils/getHost.ts
@@ -1,6 +1,6 @@
-const getHost = function () {
+const getHost = function (): string {
   const url =
-    window.location != window.parent.location ? document.referrer : document.location.href;
+    window.location !== window.parent.location ? document.referrer : document.location.href;
   return url.split('/')[2];
 };
 

--- a/frontend/src/utils/hexToRgb.js
+++ b/frontend/src/utils/hexToRgb.js
@@ -4,7 +4,7 @@ export default function hexToRgb(c) {
     return vals.split(',');
   }
   if (/^#([a-f0-9]{3}){1,2}$/.test(c)) {
-    if (c.length == 4) {
+    if (c.length === 4) {
       c = '#' + [c[1], c[1], c[2], c[2], c[3], c[3]].join('');
     }
     c = '0x' + c.substring(1);

--- a/frontend/src/utils/match.ts
+++ b/frontend/src/utils/match.ts
@@ -1,4 +1,4 @@
-export const matchMedian = (arr: number[]) => {
+export const matchMedian = (arr: number[]): number => {
   const mid = Math.floor(arr.length / 2);
   const nums = [...arr].sort((a, b) => a - b);
   return arr.length % 2 !== 0 ? nums[mid] : (nums[mid - 1] + nums[mid]) / 2;

--- a/frontend/src/utils/prettyNumbers.test.ts
+++ b/frontend/src/utils/prettyNumbers.test.ts
@@ -37,7 +37,7 @@ describe('amountToString', () => {
       { input: ['100.00', true, 50, undefined], output: '50-NaN' },
       { input: ['100.00', true, 50, 150], output: '50-150' },
     ].forEach((it) => {
-      const params: any[] = it.input || [];
+      const params: any[] = it?.input ?? [];
       const response = amountToString(params[0], params[1], params[2], params[3]);
       expect(response).toBe(it.output);
     });

--- a/frontend/src/utils/prettyNumbers.ts
+++ b/frontend/src/utils/prettyNumbers.ts
@@ -12,19 +12,19 @@ export const pn = (value?: number | null): string | undefined => {
 
 export const amountToString: (
   amount: string,
-  has_range: boolean,
-  min_amount: number,
-  max_amount: number,
+  hasRange: boolean,
+  minAmount: number,
+  maxAmount: number,
   precision?: number,
-) => string = (amount, has_range, min_amount, max_amount, precision = 4) => {
-  if (has_range) {
-    return (
-      pn(parseFloat(Number(min_amount).toPrecision(precision))) +
-      '-' +
-      pn(parseFloat(Number(max_amount).toPrecision(precision)))
-    );
+) => string = (amount, hasRange, minAmount, maxAmount, precision = 4) => {
+  if (hasRange) {
+    const rangeStart = pn(parseFloat(Number(minAmount).toPrecision(precision)));
+    const rangeEnd = pn(parseFloat(Number(maxAmount).toPrecision(precision)));
+    if (rangeStart !== undefined && rangeEnd !== undefined) {
+      return `${rangeStart}-${rangeEnd}`;
+    }
   }
-  return pn(parseFloat(Number(amount).toPrecision(precision))) || '';
+  return pn(parseFloat(Number(amount).toPrecision(precision))) ?? '';
 };
 
 export default pn;

--- a/frontend/src/utils/saveFile.ts
+++ b/frontend/src/utils/saveFile.ts
@@ -3,7 +3,7 @@
  * @param {filename} data -- object to save
  */
 
-const saveAsJson = (filename, dataObjToWrite) => {
+const saveAsJson = (filename: string, dataObjToWrite): void => {
   const blob = new Blob([JSON.stringify(dataObjToWrite, null, 2)], { type: 'text/json' });
   const link = document.createElement('a');
 

--- a/frontend/src/utils/statusBadgeColor.ts
+++ b/frontend/src/utils/statusBadgeColor.ts
@@ -1,4 +1,4 @@
-export default function statusBadgeColor(status: string) {
+export default function statusBadgeColor(status: string): string {
   if (status === 'Active') {
     return 'success';
   }

--- a/frontend/src/utils/token.ts
+++ b/frontend/src/utils/token.ts
@@ -24,7 +24,7 @@ export function validateTokenEntropy(token: string): TokenEntropy {
   // Count number of occurrences of each character
   for (let i = 0; i < len; i++) {
     const char = token.charAt(i);
-    if (charCounts[char]) {
+    if (charCounts[char] !== undefined && !isNaN(charCounts[char])) {
       charCounts[char]++;
     } else {
       charCounts[char] = 1;

--- a/frontend/src/utils/webln.ts
+++ b/frontend/src/utils/webln.ts
@@ -1,19 +1,22 @@
-import { requestProvider, type WeblnProvider } from 'webln';
+import { requestProvider, type WebLNProvider } from 'webln';
 
-const getWebln = async (): Promise<WeblnProvider> => {
-  const resultPromise = new Promise<WeblnProvider>(async (resolve, reject) => {
-    try {
-      const webln = await requestProvider();
-      if (webln) {
-        webln.enable();
-        resolve(webln);
-      }
-    } catch (err) {
-      console.log("Coulnd't connect to Webln");
-      reject();
-    }
+const getWebln = async (): Promise<WebLNProvider> => {
+  const resultPromise = new Promise<WebLNProvider>((resolve, reject) => {
+    requestProvider()
+      .then((webln) => {
+        if (webln.enable !== undefined) {
+          webln.enable().catch((error) => {
+            console.error("Couldn't enable Webln:", error);
+            reject(error);
+          });
+          resolve(webln);
+        }
+      })
+      .catch((error) => {
+        console.log("Couldn't connect to Webln:", error);
+        reject(new Error("Couldn't connect to Webln"));
+      });
   });
-
   return await resultPromise;
 };
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -13,5 +13,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src/"]
 }


### PR DESCRIPTION
## What does this PR do?
Fixes #591

This PR refactors many lines in many files to comply with all the currently defined eslint rules. 
This PR tells elsint to ignore .js files. It seems reasonable because most .js files are libraries. 
This PR selectively disables eslint checking of exhaustive dependancies in the useEffect dependency array. I do not know a better solution, as sometimes adding every dependency can cause unnecessary re-renders.

**However, I did not test very much...**

## Checklist before merging
  - [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.