### PR TITLE
Replace isort, black, flake8 with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-# TODO
-# add a hook which automatically generates the OpenApi schema on API changes
-# and places them in an appropriate location
 exclude: '(api|chat|control)/migrations/.*'
 repos:
   - repo: 'https://github.com/pre-commit/pre-commit-hooks'
@@ -50,27 +47,20 @@ repos:
         files: ^mobile/
         types_or: [javascript, jsx, ts, tsx, css, markdown, json] # uses https://github.com/pre-commit/identify
         entry: bash -c 'cd mobile && npm run format'
-      - id: isort
-        name: isort
-        stages:
-          - commit
-          - merge-commit
-        language: system
-        types: [python]
-        entry: isort
-      - id: black
-        name: black
-        stages:
-          - commit
-          - merge-commit
-        language: system
-        types: [python]
-        entry: black
-      - id: flake8
-        name: flake8
-        stages:
-          - commit
-          - merge-commit
-        language: system
-        types: [python]
-        entry: flake8
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.11
+    hooks:
+    - id: ruff
+      stages:
+        - commit
+        - merge-commit
+      language: system
+      args: [ --fix ]
+      types: [python]
+    - id: ruff-format
+      stages:
+        - commit
+        - merge-commit
+      language: system
+      types: [python]
+

--- a/api/management/commands/telegram_watcher.py
+++ b/api/management/commands/telegram_watcher.py
@@ -11,7 +11,6 @@ from api.utils import get_session
 
 
 class Command(BaseCommand):
-
     help = "Polls telegram /getUpdates method"
     rest = 3  # seconds between consecutive polls
 

--- a/api/models/currency.py
+++ b/api/models/currency.py
@@ -6,7 +6,6 @@ from django.utils import timezone
 
 
 class Currency(models.Model):
-
     with open("frontend/static/assets/currencies.json") as f:
         currency_dict = json.load(f)
     currency_choices = [(int(val), label) for val, label in list(currency_dict.items())]

--- a/control/admin.py
+++ b/control/admin.py
@@ -8,7 +8,6 @@ from control.models import AccountingDay, BalanceLog
 
 @admin.register(AccountingDay)
 class AccountingDayAdmin(ImportExportModelAdmin):
-
     list_display = (
         "day",
         "contracted",
@@ -34,7 +33,6 @@ class AccountingDayAdmin(ImportExportModelAdmin):
 
 @admin.register(BalanceLog)
 class BalanceLogAdmin(ImportExportModelAdmin):
-
     list_display = (
         "time",
         "total",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
-[tool.isort]
-profile = "black"
+[tool.ruff]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    "*migrations/*",
+    "api/nick_generator/nick_generator.py",
+    ]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
## What does this PR do?
Replaces pre-commit hooks of `isort`, `flake8`, `pyflake`, `black` with `ruff`.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.