### PR TITLE
Fix book table object updates

### DIFF
--- a/frontend/src/components/BookTable/BookControl.tsx
+++ b/frontend/src/components/BookTable/BookControl.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Typography,
@@ -16,26 +16,24 @@ import { useTheme } from '@mui/system';
 import { AutocompletePayments } from '../MakerForm';
 import { fiatMethods, swapMethods, PaymentIcon } from '../PaymentMethods';
 import { FlagWithProps } from '../Icons';
+import { AppContext, type UseAppStoreType } from '../../contexts/AppContext';
 
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
-import { type Favorites } from '../../models';
 import SwapCalls from '@mui/icons-material/SwapCalls';
 
 interface BookControlProps {
   width: number;
-  fav: Favorites;
-  setFav: (state: Favorites) => void;
   paymentMethod: string[];
   setPaymentMethods: () => void;
 }
 
 const BookControl = ({
   width,
-  fav,
-  setFav,
   paymentMethod,
   setPaymentMethods,
 }: BookControlProps): JSX.Element => {
+  const { fav, setFav } = useContext<UseAppStoreType>(AppContext);
+
   const { t, i18n } = useTranslation();
   const theme = useTheme();
 

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -255,7 +255,7 @@ const BookTable = ({
           ? t(fav.mode === 'fiat' ? 'Seller' : 'Swapping Out')
           : t(fav.mode === 'fiat' ? 'Buyer' : 'Swapping In'),
     };
-  }, []);
+  }, [fav.mode]);
 
   const amountObj = useCallback((width: number) => {
     return {
@@ -277,7 +277,7 @@ const BookTable = ({
         );
       },
     };
-  }, []);
+  }, [fav.mode]);
 
   const currencyObj = useCallback((width: number) => {
     return {
@@ -322,7 +322,7 @@ const BookTable = ({
         );
       },
     };
-  }, []);
+  }, [fav.mode]);
 
   const paymentSmallObj = useCallback((width: number) => {
     return {

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -103,7 +103,7 @@ const BookTable = ({
   showNoResults = true,
   onOrderClicked = () => null,
 }: BookTableProps): JSX.Element => {
-  const { book, fetchBook, fav, setFav, baseUrl } = useContext<UseAppStoreType>(AppContext);
+  const { book, fetchBook, fav, baseUrl } = useContext<UseAppStoreType>(AppContext);
 
   const { t } = useTranslation();
   const theme = useTheme();
@@ -797,8 +797,6 @@ const BookTable = ({
           componentsProps={{
             toolbar: {
               width,
-              fav,
-              setFav,
               paymentMethod: paymentMethods,
               setPaymentMethods,
             },
@@ -834,8 +832,6 @@ const BookTable = ({
             componentsProps={{
               toolbar: {
                 width,
-                fav,
-                setFav,
                 paymentMethod: paymentMethods,
                 setPaymentMethods,
               },

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -264,15 +264,15 @@ const BookTable = ({
       type: 'number',
       width: width * fontSize,
       renderCell: (params: any) => {
-        const amount = fav.mode === 'swap' ? params.row.amount * 100000 : params.row.amount;
+        const amount = fav.mode === 'swap' ? params.row.amount * 100 : params.row.amount;
         const minAmount =
-          fav.mode === 'swap' ? params.row.min_amount * 100000 : params.row.min_amount;
+          fav.mode === 'swap' ? params.row.min_amount * 100 : params.row.min_amount;
         const maxAmount =
-          fav.mode === 'swap' ? params.row.max_amount * 100000 : params.row.max_amount;
+          fav.mode === 'swap' ? params.row.max_amount * 100 : params.row.max_amount;
         return (
           <div style={{ cursor: 'pointer' }}>
             {amountToString(amount, params.row.has_range, minAmount, maxAmount) +
-              (fav.mode === 'swap' ? 'K Sats' : '')}
+              (fav.mode === 'swap' ? 'M Sats' : '')}
           </div>
         );
       },


### PR DESCRIPTION
## What does this PR do?
Fixes #1077

This PR introduces a fix to the book table objects that makes them listen to favorite mode changes to trigger their rendering. It also formats swap amounts in millionths instead of thousandths of satoshis, which I think looks better.

New look:

![book_order_swaps](https://github.com/RoboSats/robosats/assets/131321480/f0b17e70-f3ab-409c-a6d7-fe305ec6587b)

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.