### PR TITLE
Fix coordinator selector maker page

### DIFF
--- a/frontend/src/components/BookTable/BookControl.tsx
+++ b/frontend/src/components/BookTable/BookControl.tsx
@@ -20,7 +20,7 @@ import { AppContext, type UseAppStoreType } from '../../contexts/AppContext';
 
 import CheckBoxOutlineBlankIcon from '@mui/icons-material/CheckBoxOutlineBlank';
 import SwapCalls from '@mui/icons-material/SwapCalls';
-import { FederationContext, UseFederationStoreType } from '../../contexts/FederationContext';
+import { FederationContext, type UseFederationStoreType } from '../../contexts/FederationContext';
 import RobotAvatar from '../RobotAvatar';
 
 interface BookControlProps {

--- a/frontend/src/components/Dialogs/Coordinator.tsx
+++ b/frontend/src/components/Dialogs/Coordinator.tsx
@@ -545,7 +545,7 @@ const CoordinatorDialog = ({ open = false, onClose, network, shortAlias }: Props
 
                   <Divider />
 
-                  {coordinator?.info?.swap_enabled === false ? (
+                  {!coordinator?.info?.swap_enabled ? (
                     <ListItem {...listItemProps}>
                       <ListItemIcon>
                         <LinkIcon />

--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -2,7 +2,6 @@ import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   InputAdornment,
-  LinearProgress,
   ButtonGroup,
   Slider,
   Switch,
@@ -103,7 +102,7 @@ const MakerForm = ({
 
   useEffect(() => {
     updateCoordinatorInfo();
-  }, [maker.coordinator]);
+  }, [maker.coordinator, coordinatorUpdatedAt]);
 
   const updateCoordinatorInfo = (): void => {
     if (maker.coordinator != null) {
@@ -516,7 +515,9 @@ const MakerForm = ({
       (makerHasAmountRange && (minAmountError || maxAmountError)) ||
       (!makerHasAmountRange && maker.amount <= 0) ||
       (maker.isExplicit && (maker.badSatoshisText !== '' || maker.satoshis === '')) ||
-      (!maker.isExplicit && maker.badPremiumText !== '')
+      (!maker.isExplicit && maker.badPremiumText !== '') ||
+      federation.getCoordinator(maker.coordinator)?.info === undefined ||
+      federation.getCoordinator(maker.coordinator)?.limits === undefined
     );
   }, [maker, amountLimits, coordinatorUpdatedAt, fav.type, makerHasAmountRange]);
 
@@ -613,11 +614,6 @@ const MakerForm = ({
         }}
         zoom={maker.latitude != null && maker.longitude != null ? 6 : undefined}
       />
-      <Collapse in={Object.keys(limits).lenght === 0}>
-        <div style={{ display: Object.keys(limits) === 0 ? '' : 'none' }}>
-          <LinearProgress />
-        </div>
-      </Collapse>
       <Collapse in={!(Object.keys(limits).lenght === 0 || collapseAll)}>
         <Grid container justifyContent='space-between' spacing={0} sx={{ maxHeight: '1em' }}>
           <Grid item>
@@ -1165,10 +1161,10 @@ const MakerForm = ({
       </Collapse>
 
       <SelectCoordinator
-        coordinator={maker.coordinator}
-        setCoordinator={(coordinator) => {
+        coordinatorAlias={maker.coordinator}
+        setCoordinator={(coordinatorAlias) => {
           setMaker((maker) => {
-            return { ...maker, coordinator };
+            return { ...maker, coordinator: coordinatorAlias };
           });
         }}
       />

--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -40,7 +40,6 @@ import type Coordinator from '../../models';
 import { statusBadgeColor, pn, amountToString, computeSats } from '../../utils';
 import TakeButton from './TakeButton';
 import { F2fMapDialog } from '../Dialogs';
-import { GarageContext, type UseGarageStoreType } from '../../contexts/GarageContext';
 import { type UseFederationStoreType, FederationContext } from '../../contexts/FederationContext';
 import { type Order } from '../../models';
 

--- a/frontend/src/contexts/FederationContext.tsx
+++ b/frontend/src/contexts/FederationContext.tsx
@@ -106,7 +106,7 @@ export const FederationContextProvider = ({
   useEffect(() => {
     // On bitcoin network change we reset book, limits and federation info and fetch everything again
     const newFed = initialFederationContext.federation;
-    newFed.registerHook('onFederationReady', () => {
+    newFed.registerHook('onFederationUpdate', () => {
       setFederationUpdatedAt(new Date().toISOString());
     });
     newFed.registerHook('onCoordinatorUpdate', () => {

--- a/frontend/src/contexts/FederationContext.tsx
+++ b/frontend/src/contexts/FederationContext.tsx
@@ -107,10 +107,10 @@ export const FederationContextProvider = ({
     // On bitcoin network change we reset book, limits and federation info and fetch everything again
     const newFed = initialFederationContext.federation;
     newFed.registerHook('onFederationReady', () => {
-      setCoordinatorUpdatedAt(new Date().toISOString());
+      setFederationUpdatedAt(new Date().toISOString());
     });
     newFed.registerHook('onCoordinatorUpdate', () => {
-      setFederationUpdatedAt(new Date().toISOString());
+      setCoordinatorUpdatedAt(new Date().toISOString());
     });
     void newFed.start(origin, settings, hostUrl);
     setFederation(newFed);

--- a/frontend/src/models/Exchange.model.ts
+++ b/frontend/src/models/Exchange.model.ts
@@ -43,7 +43,7 @@ export const updateExchangeInfo = (federation: Federation): ExchangeInfo => {
       premiums[index] = coordinator.info.last_day_nonkyc_btc_premium;
       volumes[index] = coordinator.info.last_day_volume;
       highestVersion = getHigherVer(highestVersion, coordinator.info.version);
-      active_robots_today = Math.max(active_robots_today, coordinator.info['active_robots_today']);
+      active_robots_today = Math.max(active_robots_today, coordinator.info.active_robots_today);
 
       aggregations.forEach((key: any) => {
         info[key] = Number(info[key]) + Number(coordinator.info[key]);

--- a/frontend/src/models/Federation.model.ts
+++ b/frontend/src/models/Federation.model.ts
@@ -11,7 +11,7 @@ import defaultFederation from '../../static/federation.json';
 import { getHost } from '../utils';
 import { updateExchangeInfo } from './Exchange.model';
 
-type FederationHooks = 'onCoordinatorUpdate' | 'onFederationReady';
+type FederationHooks = 'onCoordinatorUpdate' | 'onFederationUpdate';
 
 export class Federation {
   constructor() {
@@ -34,7 +34,7 @@ export class Federation {
     this.book = [];
     this.hooks = {
       onCoordinatorUpdate: [],
-      onFederationReady: [],
+      onFederationUpdate: [],
     };
     this.loading = true;
   }
@@ -67,7 +67,7 @@ export class Federation {
     this.loading = this.exchange.loadingCoordinators > 0;
     if (Object.values(this.coordinators).every((coor) => coor.isUpdated())) {
       this.updateExchange();
-      this.triggerHook('onFederationReady');
+      this.triggerHook('onFederationUpdate');
     }
   };
 
@@ -119,7 +119,7 @@ export class Federation {
 
   updateExchange = (): void => {
     this.exchange.info = updateExchangeInfo(this);
-    this.triggerHook('onCoordinatorUpdate');
+    this.triggerHook('onFederationUpdate');
   };
 
   // Fetchs

--- a/frontend/src/models/Federation.model.ts
+++ b/frontend/src/models/Federation.model.ts
@@ -119,6 +119,7 @@ export class Federation {
 
   updateExchange = (): void => {
     this.exchange.info = updateExchangeInfo(this);
+    this.triggerHook('onCoordinatorUpdate');
   };
 
   // Fetchs

--- a/frontend/src/models/Garage.model.ts
+++ b/frontend/src/models/Garage.model.ts
@@ -126,7 +126,7 @@ class Garage {
   ) => {
     if (!token || !shortAlias) return;
 
-    let slot = this.getSlot(token);
+    const slot = this.getSlot(token);
 
     if (slot != null) {
       slot.updateRobot(shortAlias, { token, ...attributes });

--- a/frontend/src/utils/filterOrders.ts
+++ b/frontend/src/utils/filterOrders.ts
@@ -69,13 +69,13 @@ const filterOrders = function ({
   const filteredOrders = orders.filter((order) => {
     const typeChecks = order.type === baseFilter.type || baseFilter.type == null;
     const modeChecks = baseFilter.mode === 'fiat' ? !(order.currency === 1000) : true;
-    const premiumChecks = premium != null ? filterByPremium(order, premium) : true;
+    const premiumChecks = premium !== null ? filterByPremium(order, premium) : true;
     const currencyChecks = order.currency === baseFilter.currency || baseFilter.currency === 0;
     const paymentMethodChecks =
       paymentMethods.length > 0 ? filterByPayment(order, paymentMethods) : true;
-    const amountChecks = amountFilter != null ? filterByAmount(order, amountFilter) : true;
+    const amountChecks = amountFilter !== null ? filterByAmount(order, amountFilter) : true;
     const hostChecks =
-      baseFilter.coordinator != 'any' ? filterByHost(order, baseFilter.coordinator) : true;
+      baseFilter.coordinator !== 'any' ? filterByHost(order, baseFilter.coordinator) : true;
     return (
       typeChecks &&
       modeChecks &&


### PR DESCRIPTION
## What does this PR do?
Related to #1069 Item 1

From the issue:
> Landing on /create will show coordinators not sorted by the federationLottery() . The v0.5.4 (and prior) loading bar at the top of the maker form that was shown while loadingLimits===true is also not shown, however, you can tell limits are not yet loaded because advancedOptions does not work. All of these three issues might have a common cause. Possibly adding a loading spinner next to the Coordinator aliases on the dropdown is useful (rather than hide them while the /api/info response has not yet arrived).

This PR fixes the loading of coordinator in maker selector by displaying all enabled coordinator at first and displaying a visual circular progress while `info` and `limits` are loaded from the coordinator. The `create order` button will stay disabled while this information is not loaded.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.