### PR TITLE
Fix loading robot orders

### DIFF
--- a/frontend/src/basic/RobotPage/RobotProfile.tsx
+++ b/frontend/src/basic/RobotPage/RobotProfile.tsx
@@ -75,6 +75,11 @@ const RobotProfile = ({
   const slot = garage.getSlot();
   const robot = slot?.getRobot();
 
+  console.log('robots', Object.values(slot?.robots ?? {}));
+  const loadingCoordinators = Object.values(slot?.robots ?? {}).filter(
+    (robot) => robot.loading,
+  ).length;
+  console.log('count', loadingCoordinators);
   return (
     <Grid container direction='column' alignItems='center' spacing={1} padding={1} paddingTop={2}>
       <Grid
@@ -86,7 +91,7 @@ const RobotProfile = ({
         sx={{ width: '100%' }}
       >
         <Grid item sx={{ height: '2.3em', position: 'relative' }}>
-          {slot?.hashId ? (
+          {slot?.hashId && loadingCoordinators === 0 ? (
             <Typography align='center' component='h5' variant='h5'>
               <div
                 style={{
@@ -119,7 +124,7 @@ const RobotProfile = ({
             </Typography>
           ) : (
             <>
-              <b>{t('Building your robot!')}</b>
+              <b>{t(slot?.hashId ? 'Looking for orders!' : 'Building your robot!')}</b>
               <LinearProgress />
             </>
           )}

--- a/frontend/src/basic/RobotPage/RobotProfile.tsx
+++ b/frontend/src/basic/RobotPage/RobotProfile.tsx
@@ -75,11 +75,10 @@ const RobotProfile = ({
   const slot = garage.getSlot();
   const robot = slot?.getRobot();
 
-  console.log('robots', Object.values(slot?.robots ?? {}));
   const loadingCoordinators = Object.values(slot?.robots ?? {}).filter(
     (robot) => robot.loading,
   ).length;
-  console.log('count', loadingCoordinators);
+
   return (
     <Grid container direction='column' alignItems='center' spacing={1} padding={1} paddingTop={2}>
       <Grid

--- a/frontend/src/models/Coordinator.model.ts
+++ b/frontend/src/models/Coordinator.model.ts
@@ -324,6 +324,8 @@ export class Coordinator {
 
     if (!hasEnoughEntropy) return null;
 
+    garage.updateRobot(token, this.shortAlias, { loading: true });
+
     const newAttributes = await apiClient
       .get(this.url, `${this.basePath}/api/robot/`, authHeaders)
       .then((data: any) => {


### PR DESCRIPTION
## What does this PR do?
Related to #1069 Item 5

From the issue:
> Robots can now be generated much faster than the time it takes for the response of coordinators to know if there are active orders. Users might think there is no active / past orders if they are not patient enough. We should add an indeterminate progress bar cycling while there are still pending coordinator responses after generating a new robot.

This PR extends the linear loading of the Robot page to wait for coordinators to notify if there any active order. To help the user understand the process the text changes after the `hashId` has been confirmed and while the other coordinators are not responding

![image](https://github.com/RoboSats/robosats/assets/111684255/cb2b9095-c4c7-4f21-8052-5354c1a40fa4)

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.