### PR TITLE
Fix undefined prices error

### DIFF
--- a/frontend/src/models/Limit.model.ts
+++ b/frontend/src/models/Limit.model.ts
@@ -9,7 +9,7 @@ export interface Limit {
 export type LimitList = Record<string, Limit>;
 
 export const compareUpdateLimit = (baseL: Limit, newL: Limit): Limit => {
-  if (baseL == null) {
+  if (!baseL) {
     return newL;
   } else {
     const price = (baseL.price + newL.price) / 2;


### PR DESCRIPTION
## What does this PR do?
Related to #1069 Item 1??

From the issue:
>  There seems to be an issue very rare where sometimes, after locking the bond, the ErrorBoundary is triggered and a Borked app page is show. Seems to be related to an Order object where .price is not found (null not expected).

An user reported a similar error when opening the `/offers` view, after checking when this can be possible (`Cannot read properties of undefined (reading 'price')` this has to happen on a function where `.price` is the first call to an `undefined` instance) and triangulating it also witb the locking bond action, I believe this fixes the same case. I'm specially motivated by the `baseL == null`, which seems to be a missed fix of the PR about the lintern errors.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.