### PR TITLE
Fix order navbar

### DIFF
--- a/frontend/src/basic/NavBar/NavBar.tsx
+++ b/frontend/src/basic/NavBar/NavBar.tsx
@@ -162,7 +162,7 @@ const NavBar = (): JSX.Element => {
           sx={tabSx}
           label={smallBar ? undefined : t('Order')}
           value='order'
-          disabled={!slot?.hashId || !slot?.getRobot(slot?.activeShortAlias ?? '')?.activeOrderId}
+          disabled={!slot?.getRobot()?.activeOrderId}
           icon={<Assignment />}
           iconPosition='start'
         />

--- a/frontend/src/basic/RobotPage/RobotProfile.tsx
+++ b/frontend/src/basic/RobotPage/RobotProfile.tsx
@@ -154,7 +154,7 @@ const RobotProfile = ({
           )}
         </Grid>
 
-        {loadingCoordinators > 0 ? (
+        {loadingCoordinators > 0 && !Boolean(robot?.activeOrderId) ? (
           <Grid>
             <b>{t('Looking for orders!')}</b>
             <LinearProgress />


### PR DESCRIPTION
## What does this PR do?
Related to https://github.com/RoboSats/robosats/issues/1069 Item 1

From the issue:
>  Sometimes the Order tab is not clickable even when the Robot has an active order.

Looks like sometimes `slot?.activeShortAlias` was just using the default active alias. This bug was really really hard to reproduce so I can't say 100% it was fixed. Hope this helps. 

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.``