### PR TITLE
Fix renew order refresh

### DIFF
--- a/frontend/src/basic/OrderPage/index.tsx
+++ b/frontend/src/basic/OrderPage/index.tsx
@@ -49,10 +49,15 @@ const OrderPage = (): JSX.Element => {
     setBaseUrl(`${url}${basePath}`);
 
     const orderId = Number(params.orderId);
-    if (orderId && currentOrderId.id !== orderId && currentOrderId.shortAlias !== shortAlias)
+    if (
+      orderId &&
+      currentOrderId.id !== orderId &&
+      currentOrderId.shortAlias !== shortAlias &&
+      shortAlias
+    )
       setCurrentOrderId({ id: orderId, shortAlias });
     if (!acknowledgedWarning) setOpen({ ...closeAll, warning: true });
-  }, [params]);
+  }, [params, currentOrderId]);
 
   const onClickCoordinator = function (): void {
     if (currentOrder?.shortAlias != null) {

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -118,7 +118,7 @@ interface Contract {
 const TradeBox = ({ baseUrl, onStartAgain }: TradeBoxProps): JSX.Element => {
   const { garage, orderUpdatedAt, setBadOrder } = useContext<UseGarageStoreType>(GarageContext);
   const { settings, hostUrl, origin } = useContext<UseAppStoreType>(AppContext);
-  const { federation } = useContext<UseFederationStoreType>(FederationContext);
+  const { federation, setCurrentOrderId } = useContext<UseFederationStoreType>(FederationContext);
   const navigate = useNavigate();
 
   // Buttons and Dialogs
@@ -186,6 +186,7 @@ const TradeBox = ({ baseUrl, onStartAgain }: TradeBoxProps): JSX.Element => {
             setBadOrder(data.bad_request);
           } else if (data.id !== undefined) {
             navigate(`/order/${String(currentOrder?.shortAlias)}/${String(data.id)}`);
+            setCurrentOrderId({ id: data.id, shortAlias: currentOrder?.shortAlias });
           }
         })
         .catch(() => {


### PR DESCRIPTION
## What does this PR do?
Related to https://github.com/RoboSats/robosats/issues/1069 Item 2

From the issue:
> Sometimes, renewing an order (i.e., creating a new order with same params as one that expired) will not show you the order just created (it will not trigger a reload, probably because of a very large delay between requests). However leaving the Order tab and coming back will work.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.