### PR TITLE
Fix federation summary

### DIFF
--- a/frontend/src/components/Dialogs/Exchange.tsx
+++ b/frontend/src/components/Dialogs/Exchange.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -34,11 +34,20 @@ interface Props {
 
 const ExchangeDialog = ({ open = false, onClose }: Props): JSX.Element => {
   const { t } = useTranslation();
-  const { federation } = useContext(FederationContext);
+  const { federation, federationUpdatedAt } = useContext(FederationContext);
+  const [loadingProgress, setLoadingProgress] = useState<number>(0);
 
-  const loadingProgress = useMemo(() => {
-    return (federation.exchange.onlineCoordinators / federation.exchange.totalCoordinators) * 100;
-  }, [federation.exchange.onlineCoordinators, federation.exchange.totalCoordinators]);
+  useEffect(() => federation.updateExchange(), []);
+
+  useEffect(() => {
+    setLoadingProgress(
+      (federation.exchange.onlineCoordinators / federation.exchange.totalCoordinators) * 100,
+    );
+  }, [
+    federationUpdatedAt,
+    federation.exchange.onlineCoordinators,
+    federation.exchange.totalCoordinators,
+  ]);
 
   return (
     <Dialog open={open} onClose={onClose}>
@@ -69,7 +78,7 @@ const ExchangeDialog = ({ open = false, onClose }: Props): JSX.Element => {
             </ListItemIcon>
 
             <ListItemText
-              primary={federation.exchange.totalCoordinators}
+              primary={federation.exchange.enabledCoordinators}
               secondary={t('Enabled RoboSats coordinators')}
             />
           </ListItem>

--- a/frontend/src/components/Dialogs/Exchange.tsx
+++ b/frontend/src/components/Dialogs/Exchange.tsx
@@ -37,7 +37,9 @@ const ExchangeDialog = ({ open = false, onClose }: Props): JSX.Element => {
   const { federation, federationUpdatedAt } = useContext(FederationContext);
   const [loadingProgress, setLoadingProgress] = useState<number>(0);
 
-  useEffect(() => federation.updateExchange(), []);
+  useEffect(() => {
+    if (open) federation.updateExchange();
+  }, [open]);
 
   useEffect(() => {
     setLoadingProgress(

--- a/frontend/src/components/Dialogs/Exchange.tsx
+++ b/frontend/src/components/Dialogs/Exchange.tsx
@@ -34,22 +34,14 @@ interface Props {
 
 const ExchangeDialog = ({ open = false, onClose }: Props): JSX.Element => {
   const { t } = useTranslation();
-  const { federation, federationUpdatedAt } = useContext(FederationContext);
+  const { federation, coordinatorUpdatedAt, federationUpdatedAt } = useContext(FederationContext);
   const [loadingProgress, setLoadingProgress] = useState<number>(0);
 
   useEffect(() => {
-    if (open) federation.updateExchange();
-  }, [open]);
-
-  useEffect(() => {
-    setLoadingProgress(
-      (federation.exchange.onlineCoordinators / federation.exchange.totalCoordinators) * 100,
-    );
-  }, [
-    federationUpdatedAt,
-    federation.exchange.onlineCoordinators,
-    federation.exchange.totalCoordinators,
-  ]);
+    const loadedCoordinators =
+      federation.exchange.enabledCoordinators - federation.exchange.loadingCoordinators;
+    setLoadingProgress((loadedCoordinators / federation.exchange.enabledCoordinators) * 100);
+  }, [open, coordinatorUpdatedAt, federationUpdatedAt]);
 
   return (
     <Dialog open={open} onClose={onClose}>

--- a/frontend/src/models/Exchange.model.ts
+++ b/frontend/src/models/Exchange.model.ts
@@ -12,19 +12,17 @@ interface ExchangeInfo {
   version: Version;
 }
 
-const defaultExchangeInfo: ExchangeInfo = {
-  num_public_buy_orders: 0,
-  num_public_sell_orders: 0,
-  book_liquidity: 0,
-  active_robots_today: 0,
-  last_day_nonkyc_btc_premium: 0,
-  last_day_volume: 0,
-  lifetime_volume: 0,
-  version: { major: 0, minor: 0, patch: 0 },
-};
-
 export const updateExchangeInfo = (federation: Federation): ExchangeInfo => {
-  const info: ExchangeInfo = defaultExchangeInfo;
+  const info: ExchangeInfo = {
+    num_public_buy_orders: 0,
+    num_public_sell_orders: 0,
+    book_liquidity: 0,
+    active_robots_today: 0,
+    last_day_nonkyc_btc_premium: 0,
+    last_day_volume: 0,
+    lifetime_volume: 0,
+    version: { major: 0, minor: 0, patch: 0 },
+  };
   const premiums: number[] = [];
   const volumes: number[] = [];
   let highestVersion: Version = { major: 0, minor: 0, patch: 0 };
@@ -39,7 +37,7 @@ export const updateExchangeInfo = (federation: Federation): ExchangeInfo => {
   ];
 
   Object.values(federation.coordinators).forEach((coordinator, index) => {
-    if (coordinator.info !== undefined && coordinator.enabled === true) {
+    if (coordinator.info !== undefined) {
       premiums[index] = coordinator.info.last_day_nonkyc_btc_premium;
       volumes[index] = coordinator.info.last_day_volume;
       highestVersion = getHigherVer(highestVersion, coordinator.info.version);
@@ -49,7 +47,6 @@ export const updateExchangeInfo = (federation: Federation): ExchangeInfo => {
         info[key] = Number(info[key]) + Number(coordinator.info[key]);
       });
     }
-    return null;
   });
 
   info.last_day_nonkyc_btc_premium = weightedMean(premiums, volumes);
@@ -68,7 +65,16 @@ export interface Exchange {
 }
 
 export const defaultExchange: Exchange = {
-  info: defaultExchangeInfo,
+  info: {
+    num_public_buy_orders: 0,
+    num_public_sell_orders: 0,
+    book_liquidity: 0,
+    active_robots_today: 0,
+    last_day_nonkyc_btc_premium: 0,
+    last_day_volume: 0,
+    lifetime_volume: 0,
+    version: { major: 0, minor: 0, patch: 0 },
+  },
   enabledCoordinators: 0,
   onlineCoordinators: 0,
   loadingCoordinators: 0,

--- a/frontend/src/models/Exchange.model.ts
+++ b/frontend/src/models/Exchange.model.ts
@@ -36,18 +36,20 @@ export const updateExchangeInfo = (federation: Federation): ExchangeInfo => {
     'lifetime_volume',
   ];
 
-  Object.values(federation.coordinators).forEach((coordinator, index) => {
-    if (coordinator.info !== undefined) {
-      premiums[index] = coordinator.info.last_day_nonkyc_btc_premium;
-      volumes[index] = coordinator.info.last_day_volume;
-      highestVersion = getHigherVer(highestVersion, coordinator.info.version);
-      active_robots_today = Math.max(active_robots_today, coordinator.info.active_robots_today);
+  Object.values(federation.coordinators)
+    .filter((coor) => coor.isUpdated())
+    .forEach((coordinator, index) => {
+      if (coordinator.info !== undefined) {
+        premiums[index] = coordinator.info.last_day_nonkyc_btc_premium;
+        volumes[index] = coordinator.info.last_day_volume;
+        highestVersion = getHigherVer(highestVersion, coordinator.info.version);
+        active_robots_today = Math.max(active_robots_today, coordinator.info.active_robots_today);
 
-      aggregations.forEach((key: any) => {
-        info[key] = Number(info[key]) + Number(coordinator.info[key]);
-      });
-    }
-  });
+        aggregations.forEach((key: any) => {
+          info[key] = Number(info[key]) + Number(coordinator.info[key]);
+        });
+      }
+    });
 
   info.last_day_nonkyc_btc_premium = weightedMean(premiums, volumes);
   info.version = highestVersion;

--- a/frontend/src/models/Federation.model.ts
+++ b/frontend/src/models/Federation.model.ts
@@ -65,10 +65,8 @@ export class Federation {
     this.exchange.loadingCoordinators =
       this.exchange.loadingCoordinators < 1 ? 0 : this.exchange.loadingCoordinators - 1;
     this.loading = this.exchange.loadingCoordinators > 0;
-    if (Object.values(this.coordinators).every((coor) => coor.isUpdated())) {
-      this.updateExchange();
-      this.triggerHook('onFederationUpdate');
-    }
+    this.updateExchange();
+    this.triggerHook('onFederationUpdate');
   };
 
   // Setup

--- a/frontend/src/models/Federation.model.ts
+++ b/frontend/src/models/Federation.model.ts
@@ -151,6 +151,7 @@ export class Federation {
     this.exchange.enabledCoordinators = Object.values(this.coordinators).filter(
       (c) => c.enabled,
     ).length;
+    this.triggerHook('onFederationUpdate');
   };
 }
 

--- a/frontend/src/models/Federation.model.ts
+++ b/frontend/src/models/Federation.model.ts
@@ -96,6 +96,16 @@ export class Federation {
 
   update = async (): Promise<void> => {
     this.loading = true;
+    this.exchange.info = {
+      num_public_buy_orders: 0,
+      num_public_sell_orders: 0,
+      book_liquidity: 0,
+      active_robots_today: 0,
+      last_day_nonkyc_btc_premium: 0,
+      last_day_volume: 0,
+      lifetime_volume: 0,
+      version: { major: 0, minor: 0, patch: 0 },
+    };
     this.exchange.loadingCoordinators = Object.keys(this.coordinators).length;
     for (const coor of Object.values(this.coordinators)) {
       await coor.update(() => {

--- a/frontend/src/utils/aggregateInfo.ts
+++ b/frontend/src/utils/aggregateInfo.ts
@@ -1,5 +1,3 @@
-import { type Coordinator } from '../models';
-
 interface Version {
   major: number | null;
   minor: number | null;
@@ -61,58 +59,4 @@ const getHigherVer = (ver0: Version, ver1: Version): Version => {
   }
 };
 
-export const aggregateInfo = (federation: Coordinator[]): AggregatedInfo => {
-  const info = {
-    onlineCoordinators: 0,
-    totalCoordinators: 0,
-    num_public_buy_orders: 0,
-    num_public_sell_orders: 0,
-    book_liquidity: 0,
-    active_robots_today: 0,
-    last_day_nonkyc_btc_premium: 0,
-    last_day_volume: 0,
-    lifetime_volume: 0,
-    version: { major: 0, minor: 0, patch: 0 },
-  };
-  info.totalCoordinators = federation.length;
-  const addUp: toAdd[] = [
-    'num_public_buy_orders',
-    'num_public_sell_orders',
-    'book_liquidity',
-    'active_robots_today',
-    'last_day_volume',
-    'lifetime_volume',
-  ];
-
-  addUp.map((key) => {
-    let value = 0;
-    federation.map((coordinator) => {
-      if (coordinator.info != null) {
-        value = value + coordinator.info[key];
-      }
-      return null;
-    });
-    info[key] = value;
-    return null;
-  });
-
-  const premiums: number[] = [];
-  const volumes: number[] = [];
-  let highestVersion = { major: 0, minor: 0, patch: 0 };
-  federation.map((coordinator, index) => {
-    if (coordinator.info != null) {
-      info.onlineCoordinators = info.onlineCoordinators + 1;
-      premiums[index] = coordinator.info.last_day_nonkyc_btc_premium;
-      volumes[index] = coordinator.info.last_day_volume;
-      highestVersion = getHigherVer(highestVersion, coordinator.info.version);
-    }
-    return null;
-  });
-
-  info.last_day_nonkyc_btc_premium = weightedMean(premiums, volumes);
-  info.version = highestVersion;
-
-  return info;
-};
-
-export default aggregateInfo;
+export default getHigherVer;


### PR DESCRIPTION
## What does this PR do?
Related to https://github.com/RoboSats/robosats/issues/1069 Item 3

From the issue:
> Aggregated summary stats behaves weird. The aggregation is broken. Sometimes is stuck at 0 values. It does not re-trigger on mainnet/testnet switch click. Does not trigger a updateCoordinators() when the ExchangeSummary dialog is opened (as it used to be on v0.5.4). Last 24h average premium is sometimes NaN%.

Also removed a deprecated function

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.