### PR TITLE
The value of sats that user will receive is corrected

### DIFF
--- a/frontend/src/utils/computeSats.ts
+++ b/frontend/src/utils/computeSats.ts
@@ -16,7 +16,7 @@ const computeSats = ({
 }: computeSatsProps): string | undefined => {
   const rateWithPremium = rate + premium / 100;
   let sats = (amount / rateWithPremium) * 100000000;
-  sats = sats * (1 + fee) * (1 - routingBudget);
+  sats = sats * (1 - fee) * (1 - routingBudget);
   return pn(Math.round(sats));
 };
 


### PR DESCRIPTION
## What does this PR do?
Fixes #1201

The user will receive less sats because they have to pay taker fees, which will be deducted from the total sats received after the swap in. 
Described in issue https://github.com/RoboSats/robosats/issues/1201#issuecomment-2016579563