### PR TITLE
Return json output instead of html when wrong token in Header Authorization

### DIFF
--- a/robosats/middleware.py
+++ b/robosats/middleware.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, User, update_last_login
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
+from django.http import JsonResponse
 from rest_framework.authtoken.models import Token
-from rest_framework.exceptions import AuthenticationFailed
 from robohash import Robohash
 
 from api.nick_generator.nick_generator import NickGenerator
@@ -79,8 +79,11 @@ class RobotTokenSHA256AuthenticationMiddleWare:
             return response
 
         if not is_valid_token(token_sha256_b91):
-            raise AuthenticationFailed(
-                "Robot token SHA256 was provided in the header. However it is not a valid 39 or 40 characters Base91 string."
+            return JsonResponse(
+                {
+                    "bad_request": "Robot token SHA256 was provided in the header. However it is not a valid 39 or 40 characters Base91 string."
+                },
+                status=400,
             )
 
         # Check if it is an existing robot.
@@ -123,8 +126,11 @@ class RobotTokenSHA256AuthenticationMiddleWare:
                 encrypted_private_key = request.COOKIES.get("encrypted_private_key", "")
 
             if not public_key or not encrypted_private_key:
-                raise AuthenticationFailed(
-                    "On the first request to a RoboSats coordinator, you must provide as well a valid public and encrypted private PGP keys"
+                return JsonResponse(
+                    {
+                        "bad_request": "On the first request to a RoboSats coordinator, you must provide as well a valid public and encrypted private PGP keys"
+                    },
+                    status=400,
                 )
             (
                 valid,
@@ -133,7 +139,7 @@ class RobotTokenSHA256AuthenticationMiddleWare:
                 encrypted_private_key,
             ) = validate_pgp_keys(public_key, encrypted_private_key)
             if not valid:
-                raise AuthenticationFailed(bad_keys_context)
+                return JsonResponse({"bad_request": bad_keys_context}, status=400)
 
             # Hash the token_sha256, only 1 iteration.
             # This is the second SHA256 of the user token, aka RoboSats ID


### PR DESCRIPTION
## What does this PR do?
Fixes #1246

In [robosats/middleware.py](https://github.com/RoboSats/robosats/blob/main/robosats/middleware.py) return a JsonResponse instead of raising AuthenticationFailed Exception that is turned into the general html error by django.

rest_framework.response.Response should not be used in middleware, will return django.template.response.ContentNotRenderedError.

## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.