### PR TITLE
Fix hard coded receiving method into order detail message.

### DIFF
--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -207,7 +207,7 @@ const OrderDetails = ({
         amount: amountString,
         method: order.payment_method,
       });
-      receive = t('You receive via Lightning {{amount}} Sats (Approx)', {
+      receive = t('You receive {{amount}} Sats (Approx)', {
         amount: sats,
       });
     } else {

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -464,7 +464,7 @@
   "The order has expired": "L'ordre ha expirat",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Encara no pots prendre cap ordre! Espera {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "Tu reps via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "Tu reps via Lightning {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "Reps via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "Tu envies via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "Envies via {{method}} {{amount}}",

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -464,7 +464,7 @@
   "The order has expired": "Nabídka vypršela",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Nabídku nemůžeš zatím příjmout! Počkej {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -464,7 +464,7 @@
   "The order has expired": "Die Order ist abgelaufen",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Du kannst noch keine Order annehmen! Warte {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -464,7 +464,7 @@
   "The order has expired": "The order has expired",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -464,7 +464,7 @@
   "The order has expired": "La orden ha expirado",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "¡No puedes tomar una orden aún! Espera {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -464,7 +464,7 @@
   "The order has expired": "Eskaera iraungi da",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Oraindik ezin duzu eskaerarik hartu! Itxaron{{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -464,7 +464,7 @@
   "The order has expired": "L'ordre a expiré",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Vous ne pouvez pas encore prendre un ordre! Attendez {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "Vous recevez via Lightning {{amount}} Sats (environ)",
+  "You receive {{amount}} Sats (Approx)": "Vous recevez via Lightning {{amount}} Sats (environ)",
   "You receive via {{method}} {{amount}}": "Vous recevez via {{méthode}} {{montant}}",
   "You send via Lightning {{amount}} Sats (Approx)": "Vous envoyez via Lightning {{amount}} Sats (environ)",
   "You send via {{method}} {{amount}}": "Vous envoyez via {{method}} {{amount}}",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -464,7 +464,7 @@
   "The order has expired": "L'ordine è scaduto",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "La posizione appuntata è approssimativa. La posizione esatta del luogo dell'incontro deve essere indicata nella chat crittografata.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Non puoi ancora accettare un ordine! Aspetta {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "Ricevi {{amount}} Sats via Lightning (approssimativo)",
+  "You receive {{amount}} Sats (Approx)": "Ricevi {{amount}} Sats via Lightning (approssimativo)",
   "You receive via {{method}} {{amount}}": "Ricevi {{amount}} via {{method}}",
   "You send via Lightning {{amount}} Sats (Approx)": "Invii {{amount}} Sats via Lightning (approssimativo)",
   "You send via {{method}} {{amount}}": "Invii {{amount}} via {{method}}",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -464,7 +464,7 @@
   "The order has expired": "注文は期限切れになりました",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "まだ注文を受け取ることはできません！{{timeMin}}分{{timeSec}}秒待ってください",
-  "You receive via Lightning {{amount}} Sats (Approx)": "ライトニングで{{amount}} Sats（約）を受け取ります",
+  "You receive {{amount}} Sats (Approx)": "ライトニングで{{amount}} Sats（約）を受け取ります",
   "You receive via {{method}} {{amount}}": "{{method}}で{{amount}}を受け取ります",
   "You send via Lightning {{amount}} Sats (Approx)": "ライトニングで{{amount}} Sats（約）を送信します",
   "You send via {{method}} {{amount}}": "{{method}}で{{amount}}を送信します",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -464,7 +464,7 @@
   "The order has expired": "Zamówienie wygasło",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Nie możesz jeszcze przyjąć zamówienia! Czekać {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -464,7 +464,7 @@
   "The order has expired": "A ordem expirou",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Você ainda não pode fazer um pedido! Espere {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -464,7 +464,7 @@
   "The order has expired": "Срок действия ордера истёк",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "Закрепленное местоположение является приблизительным. Точное местоположение места встречи необходимо сообщить в зашифрованном чате.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Вы ещё не можете взять ордер! Подождите {{timeMin}}м {{timeSec}}с",
-  "You receive via Lightning {{amount}} Sats (Approx)": "Вы получаете через Lightning {{amount}} Сатоши (приблизительно)",
+  "You receive {{amount}} Sats (Approx)": "Вы получаете через Lightning {{amount}} Сатоши (приблизительно)",
   "You receive via {{method}} {{amount}}": "Вы получаете через {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "Вы отправляете через Lightning {{amount}} Сатоши (приблизительно)",
   "You send via {{method}} {{amount}}": "Вы отправляете через {{method}} {{amount}}",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -464,7 +464,7 @@
   "The order has expired": "Ordern har förfallit",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Du kan inte ta en order ännu! Vänta {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/sw.json
+++ b/frontend/static/locales/sw.json
@@ -464,7 +464,7 @@
   "The order has expired": "Agizo limekwisha muda",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "Hauwezi kuchukua agizo bado! Subiri {{timeMin}}m {{timeSec}}s",
-  "You receive via Lightning {{amount}} Sats (Approx)": "Utapokea kupitia Lightning {{amount}} Sats (Takriban)",
+  "You receive {{amount}} Sats (Approx)": "Utapokea kupitia Lightning {{amount}} Sats (Takriban)",
   "You receive via {{method}} {{amount}}": "Utapokea kupitia {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "Utatuma kupitia Lightning {{amount}} Sats (Takriban)",
   "You send via {{method}} {{amount}}": "Utatuma kupitia {{method}} {{amount}}",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -464,7 +464,7 @@
   "The order has expired": "รายการหมดอายุแล้ว",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "คุณยังไม่สามารถดำเนินรายการได้! รออีก {{timeMin}} นาที {{timeSec}} วินาที",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "You receive via {{method}} {{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "You send via {{method}} {{amount}}",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -464,7 +464,7 @@
   "The order has expired": "订单已到期",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "你暂时还不能吃单！请等{{timeMin}}分 {{timeSec}}秒",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "你通过{{method}}接收{{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "你通过{{method}}发送{{amount}}",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -464,7 +464,7 @@
   "The order has expired": "訂單已到期",
   "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.": "The pinned location is approximate. The exact location for the meeting place must be exchanged in the encrypted chat.",
   "You cannot take an order yet! Wait {{timeMin}}m {{timeSec}}s": "你暫時還不能吃單！請等{{timeMin}}分 {{timeSec}}秒",
-  "You receive via Lightning {{amount}} Sats (Approx)": "You receive via Lightning {{amount}} Sats (Approx)",
+  "You receive {{amount}} Sats (Approx)": "You receive {{amount}} Sats (Approx)",
   "You receive via {{method}} {{amount}}": "你通過{{method}}接收{{amount}}",
   "You send via Lightning {{amount}} Sats (Approx)": "You send via Lightning {{amount}} Sats (Approx)",
   "You send via {{method}} {{amount}}": "你通過{{method}}發送{{amount}}",


### PR DESCRIPTION
# What does this PR do?
This PR introduces a fix for the order detail box about the receiving payment message, so users can have it more clear when they are receiving through on-chain or lightning.

I found this problem on my last transaction when even though i selected on-chain it was showing lightning, but was just a visual issue.

<img width="317" alt="Screenshot 2024-05-01 at 12 28 51" src="https://github.com/RoboSats/robosats/assets/21986811/335b8f21-cf15-4052-883a-a53d4487140e">


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.

It's important to notice that I don't have much experience with open-source or crypto, so I'm up to fix any mistake on my part.