### PR TITLE
add new param current_status to /api/order cancel

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -991,7 +991,17 @@ class Logics:
         return False, None
 
     @classmethod
-    def cancel_order(cls, order, user, state=None):
+    def cancel_order(cls, order, user, current_status=None):
+        # If current status is specified, do no cancel the order
+        # if it is not the correct one.
+        # This prevents the client from cancelling an order that
+        # recently changed status.
+        if current_status is not None:
+            if order.status != current_status:
+                return False, {
+                    "bad_request": f"Wrong status, current one is {order.status}"
+                }
+
         # Do not change order status if an is in order
         # any of these status
         do_not_cancel = [

--- a/api/oas_schemas.py
+++ b/api/oas_schemas.py
@@ -245,6 +245,11 @@ class OrderViewSchema:
                 - `17` - Maker lost dispute
                 - `18` - Taker lost dispute
 
+                The client can specify `current_status` to make sure that the
+                order is cancelled just if it is in right status.
+                If the order is not in the specified status, the server will
+                return an error without cancelling the trade.
+
                 Note that there are penalties involved for cancelling a order
                 mid-trade so use this action carefully:
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -628,10 +628,11 @@ class UpdateOrderSerializer(serializers.Serializer):
     mining_fee_rate = serializers.DecimalField(
         max_digits=6, decimal_places=3, allow_null=True, required=False, default=None
     )
-    current_status = serializers.IntegerField(
-        min_value=Decimal(0),
-        max_value=18,
+    current_status = serializers.ChoiceField(
+        choices=Order.Status.choices,
+        default=None,
         allow_null=True,
+        allow_blank=True,
         required=False,
         help_text="Current order status for the client",
     )

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -628,6 +628,13 @@ class UpdateOrderSerializer(serializers.Serializer):
     mining_fee_rate = serializers.DecimalField(
         max_digits=6, decimal_places=3, allow_null=True, required=False, default=None
     )
+    current_status = serializers.IntegerField(
+        min_value=Decimal(0),
+        max_value=18,
+        allow_null=True,
+        required=False,
+        help_text="Current order status for the client",
+    )
 
 
 class ClaimRewardSerializer(serializers.Serializer):

--- a/api/views.py
+++ b/api/views.py
@@ -511,7 +511,7 @@ class OrderView(viewsets.ViewSet):
         mining_fee_rate = serializer.data.get("mining_fee_rate")
         statement = serializer.data.get("statement")
         rating = serializer.data.get("rating")
-        current_status_int = serializer.data.get("current_status", None)
+        current_status = serializer.data.get("current_status", None)
 
         # 1) If action is take, it is a taker request!
         if action == "take":
@@ -587,16 +587,6 @@ class OrderView(viewsets.ViewSet):
 
         # 3) If action is cancel
         elif action == "cancel":
-            if current_status_int is None:
-                current_status = None
-            else:
-                if current_status_int < 0 or current_status_int >= len(Order.Status):
-                    return Response(
-                        {"bad_request": "current_status is not in the correct range"},
-                        status.HTTP_400_BAD_REQUEST
-                    )
-                current_status = Order.Status(current_status_int)
-
             valid, context = Logics.cancel_order(
                 order, request.user, current_status=current_status
             )

--- a/docs/assets/schemas/api-latest.yaml
+++ b/docs/assets/schemas/api-latest.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: RoboSats REST API
-  version: 0.6.0
+  version: 0.6.2
   x-logo:
     url: https://raw.githubusercontent.com/Reckless-Satoshi/robosats/main/frontend/static/assets/images/robosats-0.1.1-banner.png
     backgroundColor: '#FFFFFF'
@@ -1956,11 +1956,33 @@ components:
           pattern: ^-?\d{0,3}(?:\.\d{0,3})?$
           nullable: true
         current_status:
-          type: integer
-          maximum: 18
-          minimum: 0
           nullable: true
-          description: Current order status for the client
+          description: |-
+            Current order status for the client
+
+            * `0` - Waiting for maker bond
+            * `1` - Public
+            * `2` - Paused
+            * `3` - Waiting for taker bond
+            * `4` - Cancelled
+            * `5` - Expired
+            * `6` - Waiting for trade collateral and buyer invoice
+            * `7` - Waiting only for seller trade collateral
+            * `8` - Waiting only for buyer invoice
+            * `9` - Sending fiat - In chatroom
+            * `10` - Fiat sent - In chatroom
+            * `11` - In dispute
+            * `12` - Collaboratively cancelled
+            * `13` - Sending satoshis to buyer
+            * `14` - Sucessful trade
+            * `15` - Failed lightning network routing
+            * `16` - Wait for dispute resolution
+            * `17` - Maker lost dispute
+            * `18` - Taker lost dispute
+          oneOf:
+          - $ref: '#/components/schemas/StatusEnum'
+          - $ref: '#/components/schemas/BlankEnum'
+          - $ref: '#/components/schemas/NullEnum'
       required:
       - action
     Version:

--- a/docs/assets/schemas/api-latest.yaml
+++ b/docs/assets/schemas/api-latest.yaml
@@ -469,6 +469,11 @@ paths:
             - `17` - Maker lost dispute
             - `18` - Taker lost dispute
 
+            The client can specify `current_status` to make sure that the
+            order is cancelled just if it is in right status.
+            If the order is not in the specified status, the server will
+            return an error without cancelling the trade.
+
             Note that there are penalties involved for cancelling a order
             mid-trade so use this action carefully:
 
@@ -1950,6 +1955,12 @@ components:
           format: decimal
           pattern: ^-?\d{0,3}(?:\.\d{0,3})?$
           nullable: true
+        current_status:
+          type: integer
+          maximum: 18
+          minimum: 0
+          nullable: true
+          description: Current order status for the client
       required:
       - action
     Version:

--- a/robosats/settings.py
+++ b/robosats/settings.py
@@ -146,6 +146,9 @@ SPECTACULAR_SETTINGS = {
         }
     },
     "REDOC_DIST": "SIDECAR",
+    "ENUM_NAME_OVERRIDES": {
+        "StatusEnum": "api.models.order.Order.Status",
+    }
 }
 
 

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -659,7 +659,19 @@ class TradeTest(BaseAPITestCase):
         """
         trade = Trade(self.client)
         trade.publish_order()
-        trade.cancel_order()
+
+        trade.cancel_order(current_status_int=6)
+
+        data = trade.response.json()
+
+        self.assertEqual(trade.response.status_code, 400)
+        self.assertResponse(trade.response)
+
+        self.assertEqual(
+            data["bad_request"], "Wrong status, current one is 1"
+        )
+
+        trade.cancel_order(current_status_int=1)
 
         data = trade.response.json()
 

--- a/tests/utils/trade.py
+++ b/tests/utils/trade.py
@@ -112,11 +112,13 @@ class Trade:
         self.response = self.client.get(path + params, **headers)
 
     @patch("api.tasks.send_notification.delay", send_notification)
-    def cancel_order(self, robot_index=1):
+    def cancel_order(self, robot_index=1, current_status_int=None):
         path = reverse("order")
         params = f"?order_id={self.order_id}"
         headers = self.get_robot_auth(robot_index)
         body = {"action": "cancel"}
+        if current_status_int is not None:
+            body.update({"current_status": current_status_int})
         self.response = self.client.post(path + params, body, **headers)
 
     def pause_order(self, robot_index=1):


### PR DESCRIPTION
## What does this PR do?
This PR introduces a new optional parameter `current_status` that can be used when cancelling an order. The server checks if `current_status` is the correct status of the order and returns an error without cancelling the order if it is not.
This way a client can be sure to cancel an order just if the status is the one it specified.
Fixes backed and tests of #1311.

## Checklist before merging
- [X] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.