### PR TITLE
Add cancel_status param to the cancel order action

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -1024,7 +1024,17 @@ class Logics:
         return False, None
 
     @classmethod
-    def cancel_order(cls, order, user, state=None):
+    def cancel_order(cls, order, user, cancel_status=None):
+        # If cancel status is specified, do no cancel the order
+        # if it is not the correct one.
+        # This prevents the client from cancelling an order that
+        # recently changed status.
+        if cancel_status is not None:
+            if order.status != cancel_status:
+                return False, {
+                    "bad_request": f"Current order status is {order.status}, not {cancel_status}."
+                }
+
         # Do not change order status if an is in order
         # any of these status
         do_not_cancel = [

--- a/api/oas_schemas.py
+++ b/api/oas_schemas.py
@@ -245,6 +245,10 @@ class OrderViewSchema:
                 - `17` - Maker lost dispute
                 - `18` - Taker lost dispute
 
+                The client can use `cancel_status` to cancel the order only
+                if it is in the specified status. The server will
+                return an error without cancelling the trade otherwise.
+
                 Note that there are penalties involved for cancelling a order
                 mid-trade so use this action carefully:
 

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -642,6 +642,13 @@ class UpdateOrderSerializer(serializers.Serializer):
     mining_fee_rate = serializers.DecimalField(
         max_digits=6, decimal_places=3, allow_null=True, required=False, default=None
     )
+    cancel_status = serializers.ChoiceField(
+        choices=Order.Status.choices,
+        allow_null=True,
+        allow_blank=True,
+        default=None,
+        help_text="Status the order should have for it to be cancelled.",
+    )
 
 
 class ClaimRewardSerializer(serializers.Serializer):

--- a/api/views.py
+++ b/api/views.py
@@ -540,6 +540,7 @@ class OrderView(viewsets.ViewSet):
         mining_fee_rate = serializer.data.get("mining_fee_rate")
         statement = serializer.data.get("statement")
         rating = serializer.data.get("rating")
+        cancel_status = serializer.data.get("cancel_status")
 
         # 1) If action is take, it is a taker request!
         if action == "take":
@@ -571,7 +572,7 @@ class OrderView(viewsets.ViewSet):
 
         # 2) If action is cancel
         elif action == "cancel":
-            valid, context = Logics.cancel_order(order, request.user)
+            valid, context = Logics.cancel_order(order, request.user, cancel_status)
             if not valid:
                 return Response(context, status.HTTP_400_BAD_REQUEST)
 

--- a/docs/assets/schemas/api-latest.yaml
+++ b/docs/assets/schemas/api-latest.yaml
@@ -1974,6 +1974,9 @@ components:
           format: decimal
           pattern: ^-?\d{0,3}(?:\.\d{0,3})?$
           nullable: true
+        cancel_status:
+          allOf:
+          - $ref: '#/components/schemas/StatusEnum'
       required:
       - action
     Version:

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -226,7 +226,7 @@ const TradeBox = ({ currentOrder, onStartAgain }: TradeBoxProps): JSX.Element =>
 
   const cancel = function (): void {
     const order = garage.getSlot()?.activeOrder;
-    const noConfirmation = Boolean(order?.is_maker && [0, 1, 2].includes(order?.status));
+    const noConfirmation = Boolean(order?.is_maker && [0, 1, 2, 3].includes(order?.status));
 
     setLoadingButtons({ ...noLoadingButtons, cancel: true });
     submitAction({

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -203,7 +203,7 @@ const TradeBox = ({ currentOrder, onStartAgain }: TradeBoxProps): JSX.Element =>
           mining_fee_rate,
           statement,
           rating,
-		  cancel_status
+          cancel_status
         })
         .then((data: Order) => {
           setOpen(closeAll);

--- a/frontend/src/components/TradeBox/index.tsx
+++ b/frontend/src/components/TradeBox/index.tsx
@@ -150,6 +150,7 @@ const TradeBox = ({ currentOrder, onStartAgain }: TradeBoxProps): JSX.Element =>
     mining_fee_rate?: number;
     statement?: string;
     rating?: number;
+    cancel_status?: number;
   }
 
   const renewOrder = function (): void {
@@ -188,6 +189,7 @@ const TradeBox = ({ currentOrder, onStartAgain }: TradeBoxProps): JSX.Element =>
     mining_fee_rate,
     statement,
     rating,
+    cancel_status
   }: SubmitActionProps): void {
     const slot = garage.getSlot();
 
@@ -201,6 +203,7 @@ const TradeBox = ({ currentOrder, onStartAgain }: TradeBoxProps): JSX.Element =>
           mining_fee_rate,
           statement,
           rating,
+		  cancel_status
         })
         .then((data: Order) => {
           setOpen(closeAll);
@@ -222,8 +225,14 @@ const TradeBox = ({ currentOrder, onStartAgain }: TradeBoxProps): JSX.Element =>
   };
 
   const cancel = function (): void {
+    const order = garage.getSlot()?.activeOrder;
+    const noConfirmation = Boolean(order?.is_maker && [0, 1, 2].includes(order?.status));
+
     setLoadingButtons({ ...noLoadingButtons, cancel: true });
-    submitAction({ action: 'cancel' });
+    submitAction({
+        action: 'cancel',
+        cancel_status: noConfirmation ? order?.status : undefined
+    });
   };
 
   const openDispute = function (): void {

--- a/frontend/src/models/Order.model.ts
+++ b/frontend/src/models/Order.model.ts
@@ -21,6 +21,7 @@ export interface SubmitActionProps {
   statement?: string;
   rating?: number;
   amount?: number;
+  cancel_status?: number;
 }
 
 export interface TradeRobotSummary {

--- a/robosats/settings.py
+++ b/robosats/settings.py
@@ -143,6 +143,9 @@ SPECTACULAR_SETTINGS = {
         }
     },
     "REDOC_DIST": "SIDECAR",
+    "ENUM_NAME_OVERRIDES": {
+        "StatusEnum": "api.models.order.Order.Status",
+    }
 }
 
 

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -1121,7 +1121,7 @@ class TradeTest(BaseAPITestCase):
         self.assertResponse(trade.response)
 
         self.assertEqual(
-            data["bad_request"], "This order has been cancelled by the maker"
+            trade.response.json()["bad_request"], "This order has been cancelled by the maker"
         )
 
     def test_cancel_order_different_cancel_status(self):
@@ -1146,7 +1146,7 @@ class TradeTest(BaseAPITestCase):
         self.assertResponse(trade.response)
 
         self.assertEqual(
-            data["bad_request"],
+            trade.response.json()["bad_request"],
             f"Current order status is {Order.Status.PAU}, not {Order.Status.PUB}."
         )
 

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -1085,9 +1085,6 @@ class TradeTest(BaseAPITestCase):
 
         trade.cancel_order(trade.maker_index)
         data = trade.response.json()
-        self.assertEqual(
-            data["bad_request"], "This order has been cancelled by the maker"
-        )
 
         trade.get_order(trade.taker_index)
         data = trade.response.json()
@@ -1095,11 +1092,57 @@ class TradeTest(BaseAPITestCase):
             data["bad_request"], "This order has been cancelled by the maker"
         )
 
-        trade.get_order(trade.third_index)
+    def test_cancel_order_cancel_status(self):
+        """
+        Tests the cancellation of a public order using cancel_status.
+        """
+        trade = Trade(self.client)
+        trade.publish_order()
         data = trade.response.json()
+
+        self.assertEqual(trade.response.status_code, 200)
+        self.assertResponse(trade.response)
+
+        self.assertEqual(data["status_message"], Order.Status(Order.Status.PUB).label)
+
+        # Cancel order if the order status is public
+        trade.cancel_order(cancel_status=Order.Status.PUB)
+
+        self.assertEqual(trade.response.status_code, 400)
+        self.assertResponse(trade.response)
+
         self.assertEqual(
             data["bad_request"], "This order has been cancelled by the maker"
         )
+
+    def test_cancel_order_different_cancel_status(self):
+        """
+        Tests the cancellation of a paused order with a different cancel_status.
+        """
+        trade = Trade(self.client)
+        trade.publish_order()
+        trade.pause_order()
+        data = trade.response.json()
+
+        self.assertEqual(trade.response.status_code, 200)
+        self.assertResponse(trade.response)
+
+        self.assertEqual(data["status_message"], Order.Status(Order.Status.PAU).label)
+
+        # Try to cancel order if it is public
+        trade.cancel_order(cancel_status=Order.Status.PUB)
+        data = trade.response.json()
+
+        self.assertEqual(trade.response.status_code, 400)
+        self.assertResponse(trade.response)
+
+        self.assertEqual(
+            data["bad_request"],
+            f"Current order status is {Order.Status.PAU}, not {Order.Status.PUB}."
+        )
+
+        # Cancel order to avoid leaving pending HTLCs after a successful test
+        trade.cancel_order()
 
     def test_collaborative_cancel_order_in_chat(self):
         """

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -1085,8 +1085,17 @@ class TradeTest(BaseAPITestCase):
 
         trade.cancel_order(trade.maker_index)
         data = trade.response.json()
+        self.assertEqual(
+            data["bad_request"], "This order has been cancelled by the maker"
+        )
 
         trade.get_order(trade.taker_index)
+        data = trade.response.json()
+        self.assertEqual(
+            data["bad_request"], "This order has been cancelled by the maker"
+        )
+
+        trade.get_order(trade.third_index)
         data = trade.response.json()
         self.assertEqual(
             data["bad_request"], "This order has been cancelled by the maker"

--- a/tests/utils/trade.py
+++ b/tests/utils/trade.py
@@ -118,7 +118,9 @@ class Trade:
         path = reverse("order")
         params = f"?order_id={self.order_id}"
         headers = self.get_robot_auth(robot_index)
-        body = {"action": "cancel", "cancel_status": cancel_status}
+        body = {"action": "cancel"}
+        if cancel_status is not None:
+            body.update({"cancel_status": cancel_status})
         self.response = self.client.post(path + params, body, **headers)
 
     @patch("api.tasks.send_notification.delay", send_notification)

--- a/tests/utils/trade.py
+++ b/tests/utils/trade.py
@@ -114,11 +114,11 @@ class Trade:
         self.response = self.client.get(path + params, **headers)
 
     @patch("api.tasks.send_notification.delay", send_notification)
-    def cancel_order(self, robot_index=1):
+    def cancel_order(self, robot_index=1, cancel_status=None):
         path = reverse("order")
         params = f"?order_id={self.order_id}"
         headers = self.get_robot_auth(robot_index)
-        body = {"action": "cancel"}
+        body = {"action": "cancel", "cancel_status": cancel_status}
         self.response = self.client.post(path + params, body, **headers)
 
     @patch("api.tasks.send_notification.delay", send_notification)


### PR DESCRIPTION
## What does this PR do?
Fixes #1311

This PR adds the `cancel_status` parameter to the `POST /api/order` endpoint for users to specify the status in which an order should be for the cancellation to take place.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.

## Tests
<details><summary>test_cancel_order_cancel_status</summary>

```console
aftermath:~ $ docker exec test-coordinator coverage run manage.py test tests.test_trade_pipeline.TradeTest.test_cancel_order_cancel_status
Creating test database for alias 'default'...
Found 1 test(s).
System check identified no issues (0 silenced).
Regtest network was already ready. Skipping initalization.
.
----------------------------------------------------------------------
Ran 1 test in 5.832s

OK
Destroying test database for alias 'default'...
```

</details>

<details><summary>test_cancel_order_different_cancel_status</summary>

```console
aftermath:~ $ docker exec test-coordinator coverage run manage.py test tests.test_trade_pipeline.TradeTest.test_cancel_order_different_cancel_status
Creating test database for alias 'default'...
Found 1 test(s).
System check identified no issues (0 silenced).
.
----------------------------------------------------------------------
Ran 1 test in 5.898s

OK
Destroying test database for alias 'default'...
Regtest network was already ready. Skipping initalization.
```
</details>

> Some of the tests that weren't modified and are not affected by the changes failed, but I think they should be fixed in a different PR.