### PR TITLE
fix warnings DecimalField should be Decimal type

### DIFF
--- a/api/models/currency.py
+++ b/api/models/currency.py
@@ -1,5 +1,6 @@
 import json
 
+from decimal import Decimal
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.utils import timezone
@@ -18,7 +19,7 @@ class Currency(models.Model):
         decimal_places=4,
         default=None,
         null=True,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
     )
     timestamp = models.DateTimeField(default=timezone.now)
 

--- a/api/models/market_tick.py
+++ b/api/models/market_tick.py
@@ -1,5 +1,6 @@
 import uuid
 
+from decimal import Decimal
 from decouple import config
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
@@ -27,21 +28,24 @@ class MarketTick(models.Model):
         decimal_places=2,
         default=None,
         null=True,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
     )
     volume = models.DecimalField(
         max_digits=8,
         decimal_places=8,
         default=None,
         null=True,
-        validators=[MinValueValidator(0)],
+        validators=[MinValueValidator(Decimal(0))],
     )
     premium = models.DecimalField(
         max_digits=5,
         decimal_places=2,
         default=None,
         null=True,
-        validators=[MinValueValidator(-100), MaxValueValidator(999)],
+        validators=[
+            MinValueValidator(Decimal(-100)),
+            MaxValueValidator(Decimal(999))
+        ],
         blank=True,
     )
     currency = models.ForeignKey("api.Currency", null=True, on_delete=models.SET_NULL)
@@ -52,7 +56,10 @@ class MarketTick(models.Model):
         max_digits=4,
         decimal_places=4,
         default=0,
-        validators=[MinValueValidator(0), MaxValueValidator(1)],
+        validators=[
+            MinValueValidator(Decimal(0)),
+            MaxValueValidator(Decimal(1))
+        ],
     )
 
     def log_a_tick(order):

--- a/api/models/onchain_payment.py
+++ b/api/models/onchain_payment.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -58,7 +59,10 @@ class OnchainPayment(models.Model):
         default=2.05,
         null=False,
         blank=False,
-        validators=[MinValueValidator(1), MaxValueValidator(999)],
+        validators=[
+            MinValueValidator(Decimal(1)),
+            MaxValueValidator(Decimal(999))
+        ],
     )
     mining_fee_rate = models.DecimalField(
         max_digits=6,
@@ -66,7 +70,10 @@ class OnchainPayment(models.Model):
         default=2.05,
         null=False,
         blank=False,
-        validators=[MinValueValidator(1), MaxValueValidator(999)],
+        validators=[
+            MinValueValidator(Decimal(1)),
+            MaxValueValidator(Decimal(999))
+        ],
     )
     mining_fee_sats = models.PositiveBigIntegerField(default=0, null=False, blank=False)
 

--- a/api/models/order.py
+++ b/api/models/order.py
@@ -1,6 +1,7 @@
 # We use custom seeded UUID generation during testing
 import uuid
 
+from decimal import Decimal
 from decouple import config
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -90,7 +91,10 @@ class Order(models.Model):
         decimal_places=2,
         default=0,
         null=True,
-        validators=[MinValueValidator(-100), MaxValueValidator(999)],
+        validators=[
+            MinValueValidator(Decimal(-100)),
+            MaxValueValidator(Decimal(999))
+        ],
         blank=True,
     )
     # explicit
@@ -135,8 +139,8 @@ class Order(models.Model):
         default=settings.DEFAULT_BOND_SIZE,
         null=False,
         validators=[
-            MinValueValidator(settings.MIN_BOND_SIZE),  # 2  %
-            MaxValueValidator(settings.MAX_BOND_SIZE),  # 15 %
+            MinValueValidator(Decimal(settings.MIN_BOND_SIZE)),  # 2  %
+            MaxValueValidator(Decimal(settings.MAX_BOND_SIZE)),  # 15 %
         ],
         blank=False,
     )
@@ -147,8 +151,8 @@ class Order(models.Model):
         decimal_places=6,
         null=True,
         validators=[
-            MinValueValidator(-90),
-            MaxValueValidator(90),
+            MinValueValidator(Decimal(-90)),
+            MaxValueValidator(Decimal(90)),
         ],
         blank=True,
     )
@@ -157,8 +161,8 @@ class Order(models.Model):
         decimal_places=6,
         null=True,
         validators=[
-            MinValueValidator(-180),
-            MaxValueValidator(180),
+            MinValueValidator(Decimal(-180)),
+            MaxValueValidator(Decimal(180)),
         ],
         blank=True,
     )


### PR DESCRIPTION
## What does this PR do?
The warnings were caused by the validators `MinValueValidator` and `MaxValueValidator` inside a `DecimalField`.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.