### PR TITLE
add lightning protobuf files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -650,3 +650,6 @@ node
 mobile/html/Web.bundle/js*
 mobile/html/Web.bundle/css*
 mobile/html/Web.bundle/assets*
+
+# Protocol Buffers
+api/lightning/*.proto


### PR DESCRIPTION
## What does this PR do?
This way the `.proto` files generated by `scripts/generate_grpc.sh` are ignored and the git environment is kept clean.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.