### PR TITLE
small fix in get_exchange_rates

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -188,8 +188,7 @@ def get_exchange_rates(currencies):
                             blockchain_rates.append(
                                 float(blockchain_prices[currency]["last"])
                             )
-                        except Exception as e:
-                            print(e)
+                        except Exception:
                             blockchain_rates.append(np.nan)
                 api_rates.append(blockchain_rates)
 


### PR DESCRIPTION
## What does this PR do?
While running tests, the `print(e)` was printing an annoying list of currencies. 
Removing it it is also more coherent with the other currencies providers below.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.