### PR TITLE
script to generate latest api specs file

### DIFF
--- a/scripts/api-specs-update.py
+++ b/scripts/api-specs-update.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+"""Update the latest api specs file from a running django server"""
+
+import sys
+
+import urllib.request
+import urllib.error
+
+
+try:
+    urllib.request.urlretrieve(
+        "http://127.0.0.1:8000/api/schema", "docs/assets/schemas/api-latest.yaml"
+    )
+except urllib.error.URLError as e:
+    print(f"Could not fetch latests API specs: {e}", file=sys.stderr)
+    print("Make sure that the django server is running", file=sys.stderr)
+    sys.exit(1)
+
+print("Api specs successfully updated")


### PR DESCRIPTION
## What does this PR do?
Right now [docs/assets/schemas/api-latest.yaml](https://github.com/RoboSats/robosats/blob/main/docs/assets/schemas/api-latest.yaml) is updated just when running the tests in [tests/test_api.py](https://github.com/RoboSats/robosats/blob/main/tests/test_api.py) if `python3 manage.py runserver` is running. The tests can be run without the django server `python3 manage.py runserver` running, but `api-latest.yaml` will not be updated.
This script adds a way to update `api-latest.yaml` from a running django server without having to run the tests.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.