### PR TITLE
Fix devfund url typo

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -141,7 +141,7 @@ def get_devfund_pubkey(network: str) -> str:
     """
 
     session = get_session()
-    url = "https://raw.githubusercontent.com/RoboSats/robosats/main/devfund_pubey.json"
+    url = "https://raw.githubusercontent.com/RoboSats/robosats/main/devfund_pubkey.json"
 
     try:
         response = session.get(url)


### PR DESCRIPTION
## What does this PR do?
There s a typo in the devfund url

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.