### PR TITLE
AMP Support for SendPaymentRequest in lnd.py, for lnd v0.18 and above.

### DIFF
--- a/api/lightning/lnd.py
+++ b/api/lightning/lnd.py
@@ -478,6 +478,7 @@ class LNDNode:
             payment_request=lnpayment.invoice,
             fee_limit_sat=fee_limit_sat,
             timeout_seconds=timeout_seconds,
+            amp=True,
         )
 
         routerstub = router_pb2_grpc.RouterStub(cls.channel)
@@ -536,6 +537,7 @@ class LNDNode:
             fee_limit_sat=fee_limit_sat,
             timeout_seconds=timeout_seconds,
             allow_self_payment=True,
+            amp=True,
         )
 
         order = lnpayment.order_paid_LN


### PR DESCRIPTION
## AMP Support for SendPaymentRequest in lnd.py, for lnd v0.18 and above.
When users submit an amp invoice, the payout would fail if the coordinator is running lnd v0.18 and above with the following error at the lnd backed:
```
[lncli] rpc error: code = Unknown desc = the AMP flag (--amp or SendPaymentRequest.Amp) must be set to pay an AMP invoice
```

This PR simply adds two linse in lnd.py (under pay_invoice and under follow_send_payment SendPaymentRequest) to enable AMP support when sending payments, as shown below:
```python
request = router_pb2.SendPaymentRequest(
    payment_request=lnpayment.invoice,
    fee_limit_sat=fee_limit_sat,
    timeout_seconds=timeout_seconds,
    amp=True  # Added this line
)
```

This PR has been tested by Temple Of Sats coordinator for around 1 week.
No issues have been detected so far.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.