### PR TITLE
Update warning text when routing budget is not sufficient.

### DIFF
--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -449,7 +449,7 @@ class CLNNode:
             # If the cheapest possible private route is more expensive than what RoboSats is willing to pay
             if min(routes_cost) >= max_routing_fee_sats:
                 payout["context"] = {
-                    "bad_invoice": "The invoice hinted private routes are not payable within the submitted routing budget."
+                    "bad_invoice": "The invoice hinted private routes are not payable within the submitted routing budget. This can be adjusted with Advanced Options enabled."
                 }
                 return payout
 

--- a/api/lightning/lnd.py
+++ b/api/lightning/lnd.py
@@ -424,7 +424,7 @@ class LNDNode:
             # If the cheapest possible private route is more expensive than what RoboSats is willing to pay
             if min(routes_cost) >= max_routing_fee_sats:
                 payout["context"] = {
-                    "bad_invoice": "The invoice hinted private routes are not payable within the submitted routing budget."
+                    "bad_invoice": "The invoice hinted private routes are not payable within the submitted routing budget. This can be adjusted with Advanced Options enabled."
                 }
                 return payout
 


### PR DESCRIPTION
## What does this PR do?
Fixes #1436

This PR adds more clarity when the routing budget is not sufficient. More specifically, that the user can increase the budget under advanced options.

I did not test whether the UI has enough space to display the extrta text.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.