### PR TITLE
Fix trade summary sats

### DIFF
--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -181,7 +181,7 @@ const OrderDetails = ({
     const rate = Number(order.max_amount ?? order.amount) / btc_now;
 
     if (isBuyer) {
-      if (order.amount > 0) {
+      if (order.amount && order.amount > 0) {
         sats = computeSats({
           amount: order.amount,
           fee: -tradeFee,
@@ -211,7 +211,7 @@ const OrderDetails = ({
         amount: sats,
       });
     } else {
-      if (order.amount > 0) {
+      if (order.amount && order.amount > 0) {
         sats = computeSats({
           amount: order.amount,
           fee: tradeFee,


### PR DESCRIPTION
## What does this PR do?
Fixes a wrong calculation in sats to receive/sent in order summary

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.