### PR TITLE
Upgrade dependabot pip alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-celery-beat==2.7.0
 django-celery-results==2.5.1
 django-model-utils==4.5.0
 django-redis==5.4.0
-djangorestframework==3.15.0
+djangorestframework==3.15.2
 channels==4.1.0
 channels-redis==4.2.0
 celery==5.4.0
@@ -14,7 +14,7 @@ grpcio-tools==1.62.0
 numpy==1.26.4
 Pillow==11.0.0
 python-decouple==3.8
-requests==2.31.0
+requests==2.32.0
 ring==0.10.1
 gunicorn==23.0.0
 psycopg2==2.9.9


### PR DESCRIPTION
## What does this PR do?
Fixes pip dependabot alerts:

- https://github.com/RoboSats/robosats/security/dependabot/140
- https://github.com/RoboSats/robosats/security/dependabot/133

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.