### PR TITLE
Nostr order should hide when a taker sends the action

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -185,6 +185,9 @@ class Logics:
                 seconds=order.t_to_expire(Order.Status.TAK)
             )
             order.save(update_fields=["amount", "taker", "expires_at"])
+
+            nostr_send_order_event.delay(order_id=order.id)
+
             order.log(
                 f"Taken by Robot({user.robot.id},{user.username}) for {order.amount} fiat units"
             )
@@ -292,6 +295,8 @@ class Logics:
         elif order.status == Order.Status.TAK:
             cls.cancel_bond(order.taker_bond)
             cls.kick_taker(order)
+
+            nostr_send_order_event.delay(order_id=order.id)
 
             order.log("Order expired while waiting for taker bond")
             order.log("Taker bond was cancelled")


### PR DESCRIPTION
## What does this PR do?
Nostr order should hide when a taker sends the action

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.