### PR TITLE
Bugfix: avoid error upon getting succesfully cancelled order

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -225,13 +225,13 @@ class OrderView(viewsets.ViewSet):
         # 2) If order has been cancelled
         if order.status == Order.Status.UCA:
             return Response(
-                {"bad_request": "This order has been cancelled by the maker"},
-                status.HTTP_400_BAD_REQUEST,
+                {"status": "This order has been cancelled by the maker"},
+                status.HTTP_204_NO_CONTENT,
             )
         if order.status == Order.Status.CCA:
             return Response(
-                {"bad_request": "This order has been cancelled collaborativelly"},
-                status.HTTP_400_BAD_REQUEST,
+                {"status": "This order has been cancelled collaborativelly"},
+                status.HTTP_204_NO_CONTENT,
             )
 
         data = ListOrderSerializer(order).data


### PR DESCRIPTION
## What does this PR do?
Fixes #1245

This PR fixes OrderView to not return error for a successfully cancelled order.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.