### PR TITLE
Dynamically remove expired orders with nostr

### DIFF
--- a/frontend/src/services/RoboPool/index.ts
+++ b/frontend/src/services/RoboPool/index.ts
@@ -103,7 +103,21 @@ class RoboPool {
       .map((f) => f.nostrHexPubkey)
       .filter((item) => item !== undefined);
 
-    const request = ['REQ', 'subscribeBook', { authors, kinds: [38383], '#s': ['pending'] }];
+    const requestPending = [
+      'REQ',
+      'subscribeBookPending',
+      { authors, kinds: [38383], '#s': ['pending'] },
+    ];
+    const requestSuccess = [
+      'REQ',
+      'subscribeBookSucess',
+      {
+        authors,
+        kinds: [38383],
+        '#s': ['success'],
+        since: Math.floor(new Date().getTime() / 1000),
+      },
+    ];
 
     this.messageHandlers.push((_url: string, messageEvent: MessageEvent) => {
       const jsonMessage = JSON.parse(messageEvent.data);
@@ -113,7 +127,8 @@ class RoboPool {
         events.oneose();
       }
     });
-    this.sendMessage(JSON.stringify(request));
+    this.sendMessage(JSON.stringify(requestPending));
+    this.sendMessage(JSON.stringify(requestSuccess));
   };
 }
 

--- a/frontend/src/services/RoboPool/index.ts
+++ b/frontend/src/services/RoboPool/index.ts
@@ -110,7 +110,7 @@ class RoboPool {
     ];
     const requestSuccess = [
       'REQ',
-      'subscribeBookSucess',
+      'subscribeBookSuccess',
       {
         authors,
         kinds: [38383],

--- a/frontend/src/services/RoboPool/index.ts
+++ b/frontend/src/services/RoboPool/index.ts
@@ -114,7 +114,7 @@ class RoboPool {
       {
         authors,
         kinds: [38383],
-        '#s': ['success'],
+        '#s': ['success', 'canceled', 'in-progress'],
         since: Math.floor(new Date().getTime() / 1000),
       },
     ];


### PR DESCRIPTION
## What does this PR do?
Takes advantage of nostr subscription method to dynamically remove expired orders

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.