### PR TITLE
added the alert logic for the coordinators with no on chain swap

### DIFF
--- a/frontend/src/components/MakerForm/SelectCoordinator.tsx
+++ b/frontend/src/components/MakerForm/SelectCoordinator.tsx
@@ -9,6 +9,7 @@ import {
   type SelectChangeEvent,
   CircularProgress,
   Stack,
+  Alert
 } from '@mui/material';
 import { Link } from '@mui/icons-material';
 import RobotAvatar from '../RobotAvatar';
@@ -45,6 +46,13 @@ const SelectCoordinator: React.FC<SelectCoordinatorProps> = ({
 
   return (
     <Grid item>
+      <Grid sx={{ marginBottom: 1 }}>
+        {!coordinator?.info?.swap_enabled && (
+          <Alert severity='warning' sx={{ marginTop: 2 }}>
+            {t('This coordinator does not support on-chain swaps.')}
+          </Alert>
+        )}
+      </Grid>
       <Box
         sx={{
           backgroundColor: 'background.paper',

--- a/frontend/src/components/MakerForm/SelectCoordinator.tsx
+++ b/frontend/src/components/MakerForm/SelectCoordinator.tsx
@@ -9,7 +9,7 @@ import {
   type SelectChangeEvent,
   CircularProgress,
   Stack,
-  Alert
+  Alert,
 } from '@mui/material';
 import { Link } from '@mui/icons-material';
 import RobotAvatar from '../RobotAvatar';


### PR DESCRIPTION
## What does this PR do?
Fixes #1786 
For the coordinators who do not support the on chain payments if the user locked the money in bond and user only supports on chain payments it might be a problem so giving an simple alert message for the user this coordinator does not support on chain payments with out disturbing any flow of his work 

Thank you 

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.