### PR TITLE
Display market price apis in API

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -61,6 +61,7 @@ class InfoSerializer(serializers.Serializer):
             ("info", "info"),
         ]
     )
+    market_price_apis = serializers.CharField()
     notice_message = serializers.CharField()
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -853,6 +853,9 @@ class InfoView(viewsets.ViewSet):
             1 - float(config("MAKER_FEE_SPLIT"))
         )
         context["bond_size"] = settings.DEFAULT_BOND_SIZE
+        context["market_price_apis"] = config(
+            "MARKET_PRICE_APIS", cast=str, default="none"
+        )
         context["notice_severity"] = config("NOTICE_SEVERITY", cast=str, default="none")
         context["notice_message"] = config("NOTICE_MESSAGE", cast=str, default="")
         context["min_order_size"] = config("MIN_ORDER_SIZE", cast=int, default=20000)

--- a/docs/assets/schemas/api-latest.yaml
+++ b/docs/assets/schemas/api-latest.yaml
@@ -1065,6 +1065,8 @@ components:
           $ref: '#/components/schemas/Version'
         notice_severity:
           $ref: '#/components/schemas/NoticeSeverityEnum'
+        market_price_apis:
+          type: string
         notice_message:
           type: string
       required:
@@ -1080,6 +1082,7 @@ components:
       - lifetime_volume
       - lnd_version
       - maker_fee
+      - market_price_apis
       - max_order_size
       - max_swap
       - min_order_size

--- a/tests/test_api_info.py
+++ b/tests/test_api_info.py
@@ -12,6 +12,7 @@ MAKER_FEE = FEE * config("FEE_SPLIT", cast=float, default=0.125)
 TAKER_FEE = FEE * (1 - config("FEE_SPLIT", cast=float, default=0.125))
 BOND_SIZE = config("BOND_SIZE", cast=float, default=3)
 NOTICE_SEVERITY = config("NOTICE_SEVERITY", cast=str, default="none")
+MARKET_PRICE_APIS = config("MARKET_PRICE_APIS", cast=str, default="none")
 NOTICE_MESSAGE = config("NOTICE_MESSAGE", cast=str, default="")
 
 
@@ -55,6 +56,7 @@ class APIInfoTest(BaseAPITestCase):
         self.assertAlmostEqual(data["maker_fee"], MAKER_FEE)
         self.assertAlmostEqual(data["taker_fee"], TAKER_FEE)
         self.assertAlmostEqual(data["bond_size"], BOND_SIZE)
+        self.assertEqual(data["market_price_apis"], MARKET_PRICE_APIS)
         self.assertEqual(data["notice_severity"], NOTICE_SEVERITY)
         self.assertEqual(data["notice_message"], NOTICE_MESSAGE)
         self.assertEqual(data["current_swap_fee_rate"], 0)


### PR DESCRIPTION
## What does this PR do?
Fixes #1812

Display market price apis in API

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.