### PR TITLE
Update routing budget default to 2000 ppm

### DIFF
--- a/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
+++ b/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
@@ -60,7 +60,7 @@ export const defaultLightning: LightningForm = {
   advancedOptions: false,
   useCustomBudget: false,
   routingBudgetUnit: 'PPM',
-  routingBudgetPPM: 1000,
+  routingBudgetPPM: 2000,
   routingBudgetSats: undefined,
   badInvoice: '',
   useLnproxy: false,


### PR DESCRIPTION
## What does this PR do?
Users of Alby Hub and Blixt are unable to submit the invoice for the payout due to routing hints higher than 1000 ppm.