### PR TITLE
Add market price sources to coordinator summary accordion

### DIFF
--- a/frontend/src/components/Dialogs/Coordinator.tsx
+++ b/frontend/src/components/Dialogs/Coordinator.tsx
@@ -47,6 +47,7 @@ import {
   VolunteerActivism,
   Circle,
   Flag,
+  ApiOutlined,
 } from '@mui/icons-material';
 import LinkIcon from '@mui/icons-material/Link';
 
@@ -693,6 +694,19 @@ const CoordinatorDialog = ({ open = false, onClose, shortAlias }: Props): JSX.El
                     <ListItemText
                       primary={`${coordinator?.info?.last_day_nonkyc_btc_premium}%`}
                       secondary={t('24h non-KYC bitcoin premium')}
+                    />
+                  </ListItem>
+
+                  <Divider />
+
+                  <ListItem {...listItemProps}>
+                    <ListItemIcon>
+                      <ApiOutlined />
+                    </ListItemIcon>
+
+                    <ListItemText
+                      primary={coordinator?.info?.market_price_apis}
+                      secondary={t('Market price sources (for multiple the median is calculated)')}
                     />
                   </ListItem>
                 </List>

--- a/frontend/src/models/Coordinator.model.ts
+++ b/frontend/src/models/Coordinator.model.ts
@@ -58,6 +58,7 @@ export interface Info {
   openUpdateClient: boolean;
   notice_severity: 'none' | 'warning' | 'error' | 'success' | 'info';
   notice_message: string;
+  market_price_apis: string;
   loading: boolean;
 }
 

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Volum contractat total",
   "Loved by robots: receives positive comments by robots over the internet.": "Adorat pels robots: rep comentaris positius per part dels robots a través d'Internet.",
   "Maker fee": "Comissió del creador",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Canal de Matrix copiat! {{matrix}}",
   "Maximum onchain swap size": "Mida màxima del swap onchain",
   "Maximum order size": "Mida màxima de l'ordre",

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Zobchodované množství od spuštění",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Poplatek tvůrce",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Handelsvolumen insgesamt",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Makergebühr",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Lifetime contracted volume",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Maker fee",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Volumen de los contratos total",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Comisión del creador",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Guztira kontratatutako bolumena",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Egile kuota",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Volume contracté total",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Frais du createur",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Volume scambiato in totale",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Commissione dell'offerente",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "契約総額",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "メーカー手数料",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Zakontraktowana wielkość dożywotnia",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Opłata producenta",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Volume contratado desde o princípio",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Taxa do criador",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Объём контрактов за всё время",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Комиссия мейкера",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Total kontrakterad volym",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Makeravgift",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/sw.json
+++ b/frontend/static/locales/sw.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "Kiasi cha maisha kilichoidhinishwa",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "Ada ya Muunda",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "ปริมาณการซื้อขายตั้งแต่ก่อตั้งแพล้ตฟอร์ม",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "ค่าธรรมเนียม Maker",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "终身合约量",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "挂单方费用",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -265,6 +265,7 @@
   "Lifetime contracted volume": "終身合約量",
   "Loved by robots: receives positive comments by robots over the internet.": "Loved by robots: receives positive comments by robots over the internet.",
   "Maker fee": "掛單方費用",
+  "Market price sources (for multiple the median is calculated)": "Market price sources (for multiple the median is calculated)",
   "Matrix channel copied! {{matrix}}": "Matrix channel copied! {{matrix}}",
   "Maximum onchain swap size": "Maximum onchain swap size",
   "Maximum order size": "Maximum order size",


### PR DESCRIPTION
## What does this PR do?
Fixes #1812

This PR adds the market price sources used by a coordinator to obtain the market price to their profile.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.