### PR TITLE
cast DEVELOPMENT config to bool

### DIFF
--- a/robosats/routing.py
+++ b/robosats/routing.py
@@ -23,7 +23,7 @@ protocols["websocket"] = AuthMiddlewareStack(
     )
 )
 
-if config("DEVELOPMENT", default=False):
+if config("DEVELOPMENT", cast=bool, default=False):
     protocols["http"] = django_asgi_app
 
 application = ProtocolTypeRouter(protocols)

--- a/robosats/settings.py
+++ b/robosats/settings.py
@@ -40,7 +40,7 @@ with open("version.json") as f:
     VERSION = json.load(f)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-if config("DEVELOPMENT", default=False):
+if config("DEVELOPMENT", cast=bool, default=False):
     DEBUG = True
 
 ALLOWED_HOSTS = [


### PR DESCRIPTION
## What does this PR do?
This PR cast the reading of the config DEVELOPMENT to bool. Without the cast if the config is set to True or not set nothing changes, but if it is set to False, the outcome is different. The other bool options are always casted to bool.

This script shows the different outcomes:
```
#!/usr/bin/env python

from decouple import config

if config("DEVELOPMENT", cast=bool, default=False):
    print("True")
else:
    print("False")

if config("DEVELOPMENT", default=False):
    print("True")
else:
    print("False")
```

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.