### PR TITLE
fix REDIS_URL config instead of environment variable

### DIFF
--- a/robosats/celery/__init__.py
+++ b/robosats/celery/__init__.py
@@ -7,7 +7,7 @@ from celery import Celery
 from celery.schedules import crontab
 
 # You can use rabbitmq instead here.
-BASE_REDIS_URL = os.environ.get("REDIS_URL", "redis://localhost:6379")
+BASE_REDIS_URL = config("REDIS_URL", default="redis://localhost:6379")
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "robosats.settings")


### PR DESCRIPTION
## What does this PR do?
REDIS_URL should be read as a config as in [robosats/settings.py](https://github.com/RoboSats/robosats/blob/main/robosats/settings.py)

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.