### PR TITLE
add option for timing issues in tests

### DIFF
--- a/api/management/commands/follow_invoices.py
+++ b/api/management/commands/follow_invoices.py
@@ -61,6 +61,13 @@ class Command(BaseCommand):
         INVGEN / LOCKED status and do InvoiceLookupV2 every X seconds to update their status.
         """
 
+        if \
+            config("TIMING_EXTRA_IN_TESTS", cast=bool, default=False) and \
+            config("TESTING", cast=bool, default=False) and \
+            config("LNVENDOR", cast=str, default="LND") == "LND":
+            print("TIMING_EXTRA_IN_TESTS: follow_hold_invoices LND, sleeping 0.2s")
+            time.sleep(0.2)
+
         # time it for debugging
         t0 = time.time()
 


### PR DESCRIPTION
## What does this PR do?

On my powerful machine, running tests resulted in some errors. After a bit of digging I found out that it was a timing issues.
This PR adds a config option TIMING_EXTRA_IN_TESTS that when set to True, it takes some time where it should so that the tests do not fail.
If the config option is not present (default) nothing is changed.
I had this issue very sporadically on my laptop, and every time when running on an other powerful machine.
I run the tests without docker.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.