### PR TITLE
fix result not present in telegram api response

### DIFF
--- a/api/management/commands/telegram_watcher.py
+++ b/api/management/commands/telegram_watcher.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                     f.write(f"Error getting updates: {e}\n{traceback.format_exc()}\n")
                 continue
 
-            if not response["result"]:
+            if not "result" in response or not response["result"]:
                 continue
             for result in response["result"]:
                 if not result.get("message") or not result.get("message").get("text"):


### PR DESCRIPTION
## What does this PR do?
While running the coordinator I got:
```
File ".../api/management/commands/telegram_watcher.py", line 42, in handle
    if not response["result"]:
           ~~~~~~~~^^^^^^^^^^
KeyError: 'result'
```
This PR adds a check that `"result"` is present in `response`.
I think the check already present was meant for this case, but it checks if `response["result"]` is `True`/`False`.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.