### PR TITLE
fix ruff warning in telegram_watcher

### DIFF
--- a/api/management/commands/telegram_watcher.py
+++ b/api/management/commands/telegram_watcher.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
                     f.write(f"Error getting updates: {e}\n{traceback.format_exc()}\n")
                 continue
 
-            if not "result" in response or not response["result"]:
+            if "result" not in response or not response["result"]:
                 continue
             for result in response["result"]:
                 if not result.get("message") or not result.get("message").get("text"):


### PR DESCRIPTION
## What does this PR do?
I keep on forgetting to run ruff locally.
There is a problem with the github actions though. Because ruff starts complaining after a pull request has been merged, so it seems that the following pull requests are giving problems when in fact it was the pull request before (as for example in #1920 and in this one, that is fixing the error reported by ruff).

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.