### PR TITLE
Android: Add Adaptive Icons support

### DIFF
--- a/mobile/android/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M0,0h108v108h-108z" />
+</vector>

--- a/mobile/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/mobile/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,183 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:pathData="m33.8,64.92c-0,1.93 -0,3.8 -0,5.54 0.56,-0.52 1.19,-1.08 1.79,-1.66 0.19,-0.18 0.32,-0.2 0.51,-0.03 0.32,0.3 0.66,0.59 1,0.89 0.31,-0.35 0.6,-0.68 0.9,-1.02 -1.4,-1.25 -2.79,-2.47 -4.2,-3.72z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="8.42"
+          android:startY="37.07"
+          android:endX="68.63"
+          android:endY="108.24"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m46.15,75.88c-1.39,-1.23 -2.73,-2.43 -4.09,-3.64 -0.31,0.35 -0.59,0.67 -0.89,1.01 0.38,0.34 0.75,0.67 1.14,1.02 -0.52,0.53 -1.02,1.05 -1.56,1.61 1.82,0 3.58,0 5.4,0z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="4.58"
+          android:startY="29.94"
+          android:endX="68.04"
+          android:endY="104.95"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m59.78,57.16c1.14,-0.58 2.21,-1.26 3.19,-2.08 1.97,-1.66 3.5,-3.63 4.23,-6.14 0.62,-2.14 0.76,-4.33 0.54,-6.54 -0.15,-1.53 -0.56,-2.99 -1.4,-4.31 -1.79,-2.82 -4.4,-4.51 -7.6,-5.31 -2.23,-0.55 -4.51,-0.66 -6.79,-0.67 -5.94,-0.02 -11.88,-0.01 -17.82,-0.02 -0.11,-0 -0.21,0.01 -0.32,0.01 -0,6.14 -0.01,12.24 -0.01,18.34 3.93,-2.96 7.97,-3.55 12.11,-0.64 0.54,-0.51 1.08,-1 1.64,-1.52 -0.57,-0.41 -1.11,-0.81 -1.67,-1.22 1.42,-1.03 2.8,-2.03 4.18,-3.03 -0.37,-0.85 -0.22,-1.52 0.4,-1.92 0.54,-0.35 1.29,-0.25 1.72,0.22 0.44,0.48 0.47,1.22 0.08,1.73 -0.44,0.59 -1.14,0.68 -1.94,0.25 -0.7,0.86 -1.39,1.71 -2.11,2.59 0.59,0.42 1.15,0.82 1.74,1.23 -1.15,0.77 -2.26,1.52 -3.39,2.28 0.04,0.05 0.06,0.08 0.08,0.1 4.1,3.64 8.2,7.28 12.3,10.91 0.88,0.78 1.77,1.54 2.39,2.55 1.66,2.72 1.77,5.55 0.63,8.47 -0.5,1.28 -1.26,2.41 -2.28,3.44 4.87,0 9.67,0.01 14.53,0.01 -4.91,-6.22 -9.79,-12.4 -14.68,-18.59 0.1,-0.06 0.17,-0.1 0.25,-0.14z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="34.66"
+          android:startY="25.97"
+          android:endX="82.65"
+          android:endY="82.7"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m38.45,60.04c0.23,0.2 0.48,0.35 0.74,0.46 -0.43,-0.37 -0.85,-0.72 -1.27,-1.07 0.14,0.22 0.32,0.43 0.53,0.61z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="22.08"
+          android:startY="40.5"
+          android:endX="64.93"
+          android:endY="91.16"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m38.45,60.04c0.23,0.2 0.48,0.35 0.74,0.46 -0.43,-0.37 -0.85,-0.72 -1.27,-1.07 0.14,0.22 0.32,0.43 0.53,0.61z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="22.09"
+          android:startY="40.52"
+          android:endX="64.94"
+          android:endY="91.17"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m42.5,59.76c1.04,-1.18 0.91,-2.98 -0.28,-4.01 -1.2,-1.03 -3.01,-0.91 -4.05,0.28 -0.86,0.98 -0.92,2.36 -0.25,3.4 0.42,0.35 0.84,0.7 1.27,1.07 1.12,0.48 2.47,0.22 3.31,-0.74z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="22.23"
+          android:startY="36.48"
+          android:endX="70.22"
+          android:endY="93.21"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m42.5,59.76c1.04,-1.18 0.91,-2.98 -0.28,-4.01 -1.2,-1.03 -3.01,-0.91 -4.05,0.28 -0.86,0.98 -0.92,2.36 -0.25,3.4 0.42,0.35 0.84,0.7 1.27,1.07 1.12,0.48 2.47,0.22 3.31,-0.74z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="24.15"
+          android:startY="38.75"
+          android:endX="67"
+          android:endY="89.4"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m42.5,59.76c1.04,-1.18 0.91,-2.98 -0.28,-4.01 -1.2,-1.03 -3.01,-0.91 -4.05,0.28 -0.86,0.98 -0.92,2.36 -0.25,3.4 0.42,0.35 0.84,0.7 1.27,1.07 1.12,0.48 2.47,0.22 3.31,-0.74z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="24.16"
+          android:startY="38.76"
+          android:endX="67.01"
+          android:endY="89.41"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m54.88,66.66c-1.19,-1.03 -3.01,-0.91 -4.05,0.28 -1.04,1.18 -0.91,2.98 0.28,4.01 1.2,1.03 3.01,0.91 4.05,-0.28 1.04,-1.18 0.91,-2.98 -0.28,-4.01z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="24.23"
+          android:startY="34.79"
+          android:endX="72.22"
+          android:endY="91.52"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m54.88,66.66c-1.19,-1.03 -3.01,-0.91 -4.05,0.28 -1.04,1.18 -0.91,2.98 0.28,4.01 1.2,1.03 3.01,0.91 4.05,-0.28 1.04,-1.18 0.91,-2.98 -0.28,-4.01z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="26.15"
+          android:startY="37.07"
+          android:endX="69"
+          android:endY="87.73"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="m54.88,66.66c-1.19,-1.03 -3.01,-0.91 -4.05,0.28 -1.04,1.18 -0.91,2.98 0.28,4.01 1.2,1.03 3.01,0.91 4.05,-0.28 1.04,-1.18 0.91,-2.98 -0.28,-4.01z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startX="26.16"
+          android:startY="37.08"
+          android:endX="69.01"
+          android:endY="87.74"
+          android:type="linear">
+        <item android:offset="0.33" android:color="#FF1976D2"/>
+        <item android:offset="0.42" android:color="#FF2E69CC"/>
+        <item android:offset="0.61" android:color="#FF6548BE"/>
+        <item android:offset="0.78" android:color="#FF9C27B0"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/mobile/android/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/mobile/android/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/mobile/android/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/mobile/android/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@drawable/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>


### PR DESCRIPTION
Adds [Adaptive Icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive) support on Android.

Improved version of #1922.

![monochrome](https://github.com/user-attachments/assets/deefdbd2-c015-4592-947b-ebd80ada9613)

## What does this PR do?
Closes #1919.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.