### PR TITLE
change lnd down errors to general node errors

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -1327,7 +1327,7 @@ class Logics:
             print(str(e))
             if "failed to connect to all addresses" in str(e):
                 return False, {
-                    "bad_request": "The Lightning Network Daemon (LND) is down. Write in the Telegram group to make sure the staff is aware."
+                    "bad_request": "The lightning node is down. Write in the Telegram group to make sure the staff is aware."
                 }
             elif "wallet locked" in str(e):
                 return False, {
@@ -1472,7 +1472,7 @@ class Logics:
         except Exception as e:
             if "status = StatusCode.UNAVAILABLE" in str(e):
                 return False, {
-                    "bad_request": "The Lightning Network Daemon (LND) is down. Write in the Telegram group to make sure the staff is aware."
+                    "bad_request": "The lightning node is down. Write in the Telegram group to make sure the staff is aware."
                 }
 
         take_order.taker_bond = LNPayment.objects.create(
@@ -1572,7 +1572,7 @@ class Logics:
         except Exception as e:
             if "status = StatusCode.UNAVAILABLE" in str(e):
                 return False, {
-                    "bad_request": "The Lightning Network Daemon (LND) is down. Write in the Telegram group to make sure the staff is aware."
+                    "bad_request": "The lightning node is down. Write in the Telegram group to make sure the staff is aware."
                 }
 
         order.trade_escrow = LNPayment.objects.create(

--- a/api/oas_schemas.py
+++ b/api/oas_schemas.py
@@ -191,7 +191,7 @@ class OrderViewSchema:
             OpenApiExample(
                 "When Robosats node is down",
                 value={
-                    "bad_request": "The Lightning Network Daemon (LND) is down. Write in the Telegram group to make sure the staff is aware."
+                    "bad_request": "The lightning node is down. Write in the Telegram group to make sure the staff is aware."
                 },
                 status_codes=[400],
             ),
@@ -539,7 +539,7 @@ class InfoViewSchema:
               - 24h volume
               - all time volume
             - Node info
-              - lnd version
+              - node version
               - node id
               - node alias
               - network

--- a/docs/assets/schemas/api-latest.yaml
+++ b/docs/assets/schemas/api-latest.yaml
@@ -162,7 +162,7 @@ paths:
           - 24h volume
           - all time volume
         - Node info
-          - lnd version
+          - node version
           - node id
           - node alias
           - network
@@ -419,7 +419,7 @@ paths:
                   summary: When maker bond expires (as maker)
                 WhenRobosatsNodeIsDown:
                   value:
-                    bad_request: The Lightning Network Daemon (LND) is down. Write
+                    bad_request: The lightning node is down. Write
                       in the Telegram group to make sure the staff is aware.
                   summary: When Robosats node is down
           description: ''


### PR DESCRIPTION
## What does this PR do?
This PR changes the error messages that mentions LND to be general error messages about the lightning node, since the backend can be LND or core lightning

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.