### PR TITLE
cln fix invoice dropped that caused order stuck

### DIFF
--- a/api/lightning/lnd.py
+++ b/api/lightning/lnd.py
@@ -353,7 +353,7 @@ class LNDNode:
                 status = LNPayment.Status.CANCEL
 
             # LND restarted.
-            if "wallet locked, unlock it" in str(e):
+            elif "wallet locked, unlock it" in str(e):
                 print(str(timezone.now()) + " :: Wallet Locked")
 
             # Other write to logs


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug that caused cln from expiring an order when it did not found an hold invoice. The checks were only for lnd.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.