### PR TITLE
middleware cleaning

### DIFF
--- a/robosats/middleware.py
+++ b/robosats/middleware.py
@@ -42,12 +42,7 @@ class SplitAuthorizationHeaderMiddleware(MiddlewareMixin):
         auth_header = request.META.get("HTTP_AUTHORIZATION", "")
         split_auth = auth_header.split(" | ")
 
-        if len(split_auth) == 3:
-            # Deprecated in favor of len 4
-            request.META["HTTP_AUTHORIZATION"] = split_auth[0]
-            request.META["PUBLIC_KEY"] = split_auth[1]
-            request.META["ENCRYPTED_PRIVATE_KEY"] = split_auth[2]
-        elif len(split_auth) == 4:
+        if len(split_auth) == 4:
             request.META["HTTP_AUTHORIZATION"] = split_auth[0]
             request.META["PUBLIC_KEY"] = split_auth[1]
             request.META["ENCRYPTED_PRIVATE_KEY"] = split_auth[2]
@@ -122,11 +117,6 @@ class RobotTokenSHA256AuthenticationMiddleWare:
                 "ENCRYPTED_PRIVATE_KEY", ""
             ).replace("Private ", "")
             nostr_pubkey = request.META.get("NOSTR_PUBKEY", "").replace("Nostr ", "")
-
-            # Some legacy (pre-federation) clients will still send keys as cookies
-            if public_key == "" or encrypted_private_key == "":
-                public_key = request.COOKIES.get("public_key")
-                encrypted_private_key = request.COOKIES.get("encrypted_private_key", "")
 
             if not public_key or not encrypted_private_key or not nostr_pubkey:
                 return JsonResponse(


### PR DESCRIPTION
## What does this PR do?
This PR removes some old code from `middleware.py`.
Since #1985 was merged, it removes the legacy support for splitting `HTTP_AUTHORIZATION` in 3 instead of 4.
It removes support for sending authorization with cookies that really old clients pre federation were using.
I am pretty sure nobody is running such an old client that still sends cookies, but with #1985 merged these will no longer work since they were not sending the nostr pubkey.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.