### PR TITLE
add option for routing_budget_ppm in /api/rewards

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -139,7 +139,6 @@ EXP_TAKER_BOND_INVOICE = 200
 # Proportional routing fee limit (fraction of total payout: % / 100)
 PROPORTIONAL_ROUTING_FEE_LIMIT = 0.001
 # Base flat limit fee for routing in Sats (used only when proportional is lower than this)
-MIN_FLAT_ROUTING_FEE_LIMIT = 10
 MIN_FLAT_ROUTING_FEE_LIMIT_REWARD = 2
 # Routing timeouts
 REWARDS_TIMEOUT_SECONDS = 30

--- a/api/lightning/cln.py
+++ b/api/lightning/cln.py
@@ -501,7 +501,7 @@ class CLNNode:
                 * float(config("PROPORTIONAL_ROUTING_FEE_LIMIT")),
                 float(config("MIN_FLAT_ROUTING_FEE_LIMIT_REWARD")),
             )
-        )  # 200 ppm or 10 sats
+        )  # 1000 ppm or 2 sats
         timeout_seconds = int(config("REWARDS_TIMEOUT_SECONDS"))
         request = node_pb2.PayRequest(
             bolt11=lnpayment.invoice,

--- a/api/lightning/lnd.py
+++ b/api/lightning/lnd.py
@@ -472,7 +472,7 @@ class LNDNode:
                 * float(config("PROPORTIONAL_ROUTING_FEE_LIMIT")),
                 float(config("MIN_FLAT_ROUTING_FEE_LIMIT_REWARD")),
             )
-        )  # 200 ppm or 10 sats
+        )  # 1000 ppm or 2 sats
         timeout_seconds = int(config("REWARDS_TIMEOUT_SECONDS"))
         request = router_pb2.SendPaymentRequest(
             payment_request=lnpayment.invoice,

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -680,6 +680,14 @@ class ClaimRewardSerializer(serializers.Serializer):
         default=None,
         help_text="A valid LN invoice with the reward amount to withdraw",
     )
+    routing_budget_ppm = serializers.IntegerField(
+        default=0,
+        min_value=Decimal(0),
+        max_value=100_001,
+        allow_null=True,
+        required=False,
+        help_text="Max budget to allocate for routing in PPM",
+    )
 
 
 class PriceSerializer(serializers.Serializer):

--- a/api/views.py
+++ b/api/views.py
@@ -904,6 +904,7 @@ class RewardView(CreateAPIView):
             return Response(status=status.HTTP_400_BAD_REQUEST)
 
         pgp_invoice = serializer.data.get("invoice")
+        routing_budget_ppm = serializer.data.get("routing_budget_ppm", None)
 
         valid_signature, invoice = verify_signed_message(
             request.user.robot.public_key, pgp_invoice
@@ -915,7 +916,7 @@ class RewardView(CreateAPIView):
                 status.HTTP_400_BAD_REQUEST,
             )
 
-        valid, context = Logics.withdraw_rewards(request.user, invoice)
+        valid, context = Logics.withdraw_rewards(request.user, invoice, routing_budget_ppm)
 
         if not valid:
             context["successful_withdrawal"] = False


### PR DESCRIPTION
## What does this PR do?
This PR uniforms the `/api/rewards` with the `/api/order` `update_invoice` (changed in #326), adding the option `routing_budget_ppm` in `/api/rewards`, and thus fixing #1382 for the backend.
An other pull request implementing it in the frontend is needed (maybe to be incorporated in #1973). This commit still leaves the option to not specify `routing_budget_ppm` in order to be compatible with old clients, with the notice in the code that it should be deprecated in the future.
It also remove the `MIN_FLAT_ROUTING_FEE_LIMIT` variable from `.env-sample`, since after #347 it is no longer used.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.