### PR TITLE
Ignore case differences during payment methods icon matching

### DIFF
--- a/frontend/src/components/PaymentMethods/StringAsIcons.tsx
+++ b/frontend/src/components/PaymentMethods/StringAsIcons.tsx
@@ -33,9 +33,9 @@ const StringAsIcons: React.FC<StringAsIconsProps> = ({
 
     // Adds icons for each PaymentMethod that matches
     methods.forEach((method, i) => {
-      const regex = new RegExp(`\\b${method.name}\\b`, 'g');
+      const regex = new RegExp(`\\b${method.name.toLowerCase()}\\b`, 'g');
 
-      if (regex.test(customMethods)) {
+      if (regex.test(customMethods.toLowerCase())) {
         customMethods = customMethods.replace(regex, '');
         rows.push(
           <Tooltip


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/RoboSats/robosats/issues/2130

This PR modifies the way in which payment methods icons are detected by using lowecase in both sides (known payment methods and the ones used by the user). This helps avoid scenarios in which a payment method is not detected because of different  cases in the name (i.e. `PIX`, `Pix`, `pix`, `PiX`, etc.)
 
## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.