### PR TITLE
Fix swap icons color

### DIFF
--- a/frontend/src/components/BookTable/BookControl.tsx
+++ b/frontend/src/components/BookTable/BookControl.tsx
@@ -90,10 +90,10 @@ const BookControl = ({
       component = <SendReceiveIcon color='primary' />;
       text = t('Buy');
     } else if (value === 'swapin') {
-      component = <SwapCalls color='secondary' />;
+      component = <SwapCalls color='primary' />;
       text = t('Swap In');
     } else if (value === 'swapout') {
-      component = <SwapCalls color='primary' />;
+      component = <SwapCalls color='secondary' />;
       text = t('Swap Out');
     }
 
@@ -159,14 +159,6 @@ const BookControl = ({
                 </Typography>
               </div>
             </MenuItem>
-            <MenuItem value='sell' style={{ width: '8em' }}>
-              <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                <SendReceiveIcon color='secondary' sx={{ transform: 'scaleX(-1)' }} />
-                <Typography sx={{ width: '2em' }} align='right' color='text.secondary'>
-                  {' ' + t('Sell')}
-                </Typography>
-              </div>
-            </MenuItem>
             <MenuItem value='buy' style={{ width: '8em' }}>
               <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
                 <SendReceiveIcon color='primary' />
@@ -175,9 +167,17 @@ const BookControl = ({
                 </Typography>
               </div>
             </MenuItem>
+            <MenuItem value='sell' style={{ width: '8em' }}>
+              <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
+                <SendReceiveIcon color='secondary' sx={{ transform: 'scaleX(-1)' }} />
+                <Typography sx={{ width: '2em' }} align='right' color='text.secondary'>
+                  {' ' + t('Sell')}
+                </Typography>
+              </div>
+            </MenuItem>
             <MenuItem value='swapin' style={{ width: '8em' }}>
               <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                <SwapCalls color='secondary' />
+                <SwapCalls color='primary' />
                 <Typography sx={{ width: '2em' }} align='right' color='text.secondary'>
                   {' ' + t('Swap In')}
                 </Typography>
@@ -185,7 +185,7 @@ const BookControl = ({
             </MenuItem>
             <MenuItem value='swapout' style={{ width: '8em' }}>
               <div style={{ display: 'flex', alignItems: 'center', flexWrap: 'wrap' }}>
-                <SwapCalls color='primary' />
+                <SwapCalls color='secondary' />
                 <Typography sx={{ width: '2em' }} align='right' color='text.secondary'>
                   {' ' + t('Swap Out')}
                 </Typography>


### PR DESCRIPTION
## What does this PR do?

Fixes #2150 

This PR changes the colors of the order types to be consistent on the kind of trade. 

It also modifies their order in the selection menu to sort them alphabetically and keep them mixed (looks better).

<img width="143" height="264" alt="new_icons" src="https://github.com/user-attachments/assets/e0196c9f-be45-4592-9599-37b51a4c2ed0" />

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.