### PR TITLE
Fix clipboard safe string regular expression

### DIFF
--- a/android/app/src/main/java/com/robosats/WebAppInterface.kt
+++ b/android/app/src/main/java/com/robosats/WebAppInterface.kt
@@ -41,7 +41,7 @@ class WebAppInterface(private val context: MainActivity, private val webView: We
 
     // Security patterns for input validation
     private val UUID_PATTERN = Pattern.compile("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", Pattern.CASE_INSENSITIVE)
-    private val SAFE_STRING_PATTERN = Pattern.compile("^[a-zA-Z0-9\\s_\\-.,:;!?()\\[\\]{}]*$")
+    private val SAFE_STRING_PATTERN = Pattern.compile("^[a-zA-Z0-9\s_\-.,:;!?()\[\]{}\"]*$")
 
     // Maximum length for input strings
     private val MAX_INPUT_LENGTH = 1000


### PR DESCRIPTION
## What does this PR do?
Fixes https://github.com/RoboSats/robosats/issues/2152.

This PR updates the regular expression used to validate content pasted to the clipboard by removing extra backslashes and adding the double quote character (`"`).

I haven't tested it though, not sure if characters should be escaped using two backslashes (`\\[`) or one (`\[`). I followed the android documentation https://developer.android.com/reference/kotlin/java/util/regex/Pattern

<details><summary>Before</summary>

<img width="1676" height="1152" alt="regex" src="https://github.com/user-attachments/assets/927f7207-ae47-4e23-aa40-2cdff7860201" />

</details>

<details><summary>After</summary>

<img width="1844" height="1152" alt="regex_quote" src="https://github.com/user-attachments/assets/b9c36981-3433-45dd-9f90-103e3d9a33fc" />

</details>

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.