### PR TITLE
Fix frontend and web docker environments

### DIFF
--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -14,9 +14,8 @@ services:
     container_name: dev-nginx
     restart: always
     volumes:
-      - ./:/usr/src/frontend
       - ../web:/usr/src/web
+      - ./static/frontend:/usr/src/web/static/frontend
       - ../web/nginx.conf:/etc/nginx/nginx.conf
-      - ../web/coordinators/:/etc/nginx/conf.d/
     ports:
       - 8888:80

--- a/web/docker-compose.yml
+++ b/web/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
     volumes:
       - ./:/usr/src/web
+      - ../frontend/static/frontend:/usr/src/web/static/frontend
       - ./nginx.conf:/etc/nginx/nginx.conf
-      - ./coordinators/:/etc/nginx/conf.d/
     ports:
       - 8080:80


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/RoboSats/robosats/issues/2161.

This PR basically mounts the `frontend/static` folder created during the webpack compilation into both environments. Otherwise, they can't find the main files to load the user interface.

### Tests

Tested using a fresh install (after deleting all volumes) and with previous volumes untouched.

<details><summary>Logs</summary>

```console
web-dev-frontend  | webpack 5.100.2 compiled with 2 warnings in 49944 ms
web-dev-frontend exited with code 0
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET / HTTP/1.1" 304 0 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/css/fonts.css HTTP/1.1" 200 7679 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/css/loader.css HTTP/1.1" 200 4556 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/css/index.css HTTP/1.1" 200 3330 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/css/leaflet.css HTTP/1.1" 200 16429 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/frontend/main.v0.8.1.250914b65da7e6a60e99.js HTTP/1.1" 200 3386206 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/css/fonts/roboto-14.woff2 HTTP/1.1" 200 15688 "http://localhost:8080/static/css/fonts.css" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/frontend/30709cffba13a782af5d.module.wasm HTTP/1.1" 200 1070846 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/frontend/main.v0.8.1.a1da0f820829081dbebc.js HTTP/1.1" 200 12261 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/frontend/main.v0.8.1.a1da0f820829081dbebc.js HTTP/1.1" 200 12261 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/locales/en.json HTTP/1.1" 200 64385 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/frontend/5cffdf4359cd0a3c3069.module.wasm HTTP/1.1" 200 1070846 "http://localhost:8080/static/frontend/main.v0.8.1.a1da0f820829081dbebc.js" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/css/fonts/roboto-21.woff2 HTTP/1.1" 200 15920 "http://localhost:8080/static/css/fonts.css" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/assets/sounds/chat-open.mp3 HTTP/1.1" 206 2088 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/assets/sounds/taker-found.mp3 HTTP/1.1" 206 111176 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/assets/sounds/locked-invoice.mp3 HTTP/1.1" 206 92368 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /static/assets/sounds/successful.mp3 HTTP/1.1" 206 64364 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /null/relay/ HTTP/1.1" 200 3148 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:42 +0000] "GET /relay/ HTTP/1.1" 200 3148 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:45 +0000] "GET /static/css/fonts/roboto-28.woff2 HTTP/1.1" 200 15828 "http://localhost:8080/static/css/fonts.css" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:48 +0000] "GET /api/robot/ HTTP/1.1" 200 3148 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:48 +0000] "GET /null/api/robot/ HTTP/1.1" 200 3148 "http://localhost:8080/" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:51 +0000] "GET /static/assets/geo/countries-coastline-10km.geo.json HTTP/1.1" 200 1053540 "http://localhost:8080/offers" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:52 +0000] "GET /static/federation/avatars/temple.small.webp HTTP/1.1" 200 3208 "http://localhost:8080/offers" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:52 +0000] "GET /static/federation/avatars/lake.small.webp HTTP/1.1" 200 2850 "http://localhost:8080/offers" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:52 +0000] "GET /static/federation/avatars/moon.small.webp HTTP/1.1" 200 2082 "http://localhost:8080/offers" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:52 +0000] "GET /static/federation/avatars/veneto.small.webp HTTP/1.1" 200 3576 "http://localhost:8080/offers" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:57 +0000] "GET /null/relay/ HTTP/1.1" 200 3148 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:13:57 +0000] "GET /relay/ HTTP/1.1" 200 3148 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:14:27 +0000] "GET /null/relay/ HTTP/1.1" 200 3148 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
web-dev-nginx     | 172.18.0.1 - - [11/Aug/2025:11:14:27 +0000] "GET /relay/ HTTP/1.1" 200 3148 "-" "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0" "-"
```

</details>

<img width="2554" height="1348" alt="screenshot" src="https://github.com/user-attachments/assets/d0d68e3a-d87c-4726-b43b-7338861c9811" />


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.