### PR TITLE
Fix payment method icons

### DIFF
--- a/frontend/src/components/PaymentMethods/StringAsIcons.tsx
+++ b/frontend/src/components/PaymentMethods/StringAsIcons.tsx
@@ -33,10 +33,10 @@ const StringAsIcons: React.FC<StringAsIconsProps> = ({
 
     // Adds icons for each PaymentMethod that matches
     methods.forEach((method, i) => {
-      const regex = new RegExp(`\\b${method.name}\\b`, 'g');
+      const regex = new RegExp(`\\b${method.name.toLowerCase()}\\b`, 'g');
 
-      if (regex.test(customMethods)) {
-        customMethods = customMethods.replace(regex, '');
+      if (regex.test(customMethods.toLowerCase())) {
+        customMethods = customMethods.replace(method.name, '');
         rows.push(
           <Tooltip
             key={`${method.name}-${i}`}


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug in the payment method icons matching.

Payment method icons were matched using exact casing matches. 

https://github.com/RoboSats/robosats/pull/2131 fixed it by converting to lowercase but introduced a bug in the order details page (which I didn't test, my bad) by displaying the icon and the method name.

The change was reverted in https://github.com/RoboSats/robosats/pull/2159. Fixing the latter issue but introducing again the former.

Here I modify the matching again but instead replace the method name as it is from the custom methods instead of replacing the lowercase version of it, effectively getting rid of both bugs.

### Tests

<details><summary>Before</summary>

<img width="767" height="589" alt="premium" src="https://github.com/user-attachments/assets/f3c2f2f5-f425-4d91-9257-2188b69a1da5" />

</details>


<details><summary>After</summary>

<img width="838" height="585" alt="premium_3" src="https://github.com/user-attachments/assets/ad8a314b-80e0-4e2e-beac-df53122b91f6" />

</details>


## Checklist before merging

- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.