### PR TITLE
Sort by premium when the order type is defined #2146

### DIFF
--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Box,
@@ -774,6 +774,22 @@ const BookTable = ({
       : orders;
   }, [showControls, orders, fav, paymentMethods]);
 
+  const currentSortModel = useMemo(() => {
+    if (fav.type === 1) {
+      // buyer
+      return [{field: 'premium', sort: 'asc'}];
+    } else if (fav.type === 0) {
+      // seller
+      return [{field: 'premium', sort: 'desc'}];
+    } else {
+      return undefined;
+    }
+  }, [fav]);
+
+  const prevSortModel = useRef<number | undefined>();
+  const sortModel = prevSortModel.current !== fav.type ? currentSortModel : undefined;
+  prevSortModel.current = fav.type;
+
   if (!fullscreen) {
     return (
       <Paper
@@ -798,6 +814,7 @@ const BookTable = ({
           sx={headerStyleFix}
           localeText={localeText}
           rows={filteredOrders}
+          sortModel={sortModel}
           getRowId={(params: PublicOrder) => `${String(params.coordinatorShortAlias)}/${params.id}`}
           loading={federation.loading}
           columns={columns}
@@ -840,6 +857,7 @@ const BookTable = ({
             rows={filteredOrders}
             loading={federation.loading}
             columns={columns}
+            sortModel={sortModel}
             hideFooter={!showFooter}
             slots={gridComponents}
             page={page}


### PR DESCRIPTION
This PR updates the order list so that when a user selects buy or sell, orders are automatically sorted by premium:

Buy orders: Sorted ascending — most favorable premiums first.
Sell orders: Sorted descending — most favorable premiums first.