### PR TITLE
fix tor error messaging when safer or safest mode is enabled in tor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "robosats",
       "dependencies": {
         "js-yaml": "^4.1.0"
       },


### PR DESCRIPTION
The main div was always being displayed; causing the spinner to never leave. It is now hidden when js is disabled. This pr also hides it for safer mode because without wsm the app hangs so checking for wsm was used as a hack to see if the page can load correctly. this is why the noscript error is duplicated; since it applies to both safer and safest modes yet only gets displayed if js is completely disabled

these are screenshots taken when testing the fix on chrome

<img width="1343" height="729" alt="Screenshot 2025-11-12 at 1 11 43 AM" src="https://github.com/user-attachments/assets/bb17d986-2ca2-4b42-ae65-dd6519a09d25" />
<img width="1373" height="730" alt="Screenshot 2025-11-12 at 1 11 59 AM" src="https://github.com/user-attachments/assets/8b272bf7-097a-4dc2-bcf3-d4af5b7d52b4" />


screenshots taken when testing on tor

<img width="1636" height="752" alt="Screenshot 2025-11-12 at 1 13 42 AM" src="https://github.com/user-attachments/assets/58c019cb-324c-4fcc-81f0-9b556b6b9500" />
<img width="1643" height="536" alt="Screenshot 2025-11-12 at 1 13 22 AM" src="https://github.com/user-attachments/assets/6b9b1651-9d05-4732-84e9-0da4fa81fce2" />
<img width="1646" height="568" alt="Screenshot 2025-11-12 at 1 13 04 AM" src="https://github.com/user-attachments/assets/b5ac9a94-4f68-4ff6-92e4-ef86e967a992" />



## What does this PR do?
Fixes #[<ISSUE_NUMBER>](https://github.com/RoboSats/robosats/issues/2288)

