### PR TITLE
Use tor to resolve DNS

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -23,8 +23,8 @@ def get_session():
     # Tor uses the 9050 port as the default socks port
     if USE_TOR:
         session.proxies = {
-            "http": "socks5://" + TOR_PROXY,
-            "https": "socks5://" + TOR_PROXY,
+            "http": "socks5h://" + TOR_PROXY,
+            "https": "socks5h://" + TOR_PROXY,
         }
     return session
 


### PR DESCRIPTION
## What does this PR do?
Use tor for DNS resolution. With the current implementation, even if USE_TOR is set to True, DNS resolution will happen on clearnet, which may expose the coordinator identity.

By adding `h` to the proxy configuration, DNS resolution also happens through the tor network.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.