### PR TITLE
Fix typo in federation table header

### DIFF
--- a/frontend/src/components/FederationTable/index.tsx
+++ b/frontend/src/components/FederationTable/index.tsx
@@ -153,7 +153,7 @@ const FederationTable = ({
   const aliasObj = useCallback(() => {
     return {
       field: 'longAlias',
-      headerName: mobile ? '' : t('Rating'),
+      headerName: mobile ? '' : t('Alias'),
       width: mobile ? 60 : 190,
       renderCell: (params: { row: Coordinator }) => {
         const coordinator = federation.getCoordinator(params.row.shortAlias);


### PR DESCRIPTION
## What does this PR do?

This PR fixes the federation table first column header name (see image below).

<img width="639" height="598" alt="typo" src="https://github.com/user-attachments/assets/40bbcb18-a023-491f-bc26-93ed09b275e8" />

## Checklist before merging

- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.