### PR TITLE
Fix/2326 swap calculation UI

### DIFF
--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -195,7 +195,9 @@ const OrderDetails = ({
       : (coordinator.info?.taker_fee ?? 0);
     const defaultRoutingBudget = 0.001;
     const btc_now = order.satoshis_now / 100000000;
-    const rate = Number(order.max_amount ?? order.amount) / btc_now;
+    const rate =
+      (order.has_range && order.max_amount ? Number(order.max_amount) : Number(order.amount)) /
+      btc_now;
 
     if (isBuyer) {
       if (order.invoice_amount) {


### PR DESCRIPTION
## What does this PR do?
Fixes #2326 

1. Cause of the Bug:

The OrderDetails component used a helper function (amountToString) that, by default, limited the precision to 4 digits.

For an amount of 100,155 Sats, this caused rounding to 1.002 x 10^5, displaying 100,200 in the interface ("You send via...").

However, the confirmation button ("Confirm Sent") used a different calculation (toFixed(8)), displaying the exact amount converted to BTC (0.00100155), which caused the discrepancy.

1.2 Fix:

I have forced a precision of 9 digits when the currency is Bitcoin (currentOrder.currency === 1000). This ensures that the amount displayed in the order details is accurate and matches the confirmation button.

2. Cause of the Bug:

This error occurred exclusively in range orders (e.g., from 10k to 1M sats) when a taker decided to take an amount less than the maximum (e.g., 100k sats).

The interface incorrectly calculated the exchange rate using the Maximum Order Amount (1M) instead of the Actual Amount agreed upon (100k).

Since the backend reported the satoshis corresponding to the actual amount (100k), the division Maximum / Actual Sats generated an artificially inflated rate (10 times higher in this example).

When applying this inflated rate to calculate "You receive...", the result was divided by 10, displaying a much lower figure than the actual amount (e.g., 10,000 instead of 100,000).

2.2 Fix:

I reversed the priority logic in the calculation. Now the system correctly uses the Actual Amount (order.amount) if it is defined (the deal has already been closed), and only uses the maximum (order.max_amount) if a final amount has not yet been defined. This ensures that the rate and the displayed satoshis are always consistent.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.