### PR TITLE
Clear payment methods on mode change

### DIFF
--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -627,6 +627,7 @@ const MakerForm = ({
                       checked={fav.mode === 'swap'}
                       onClick={() => {
                         handleCurrencyChange(fav.mode === 'swap' ? 1 : 1000);
+                        handlePaymentMethodChange([]);
                       }}
                     />
                   </FormControl>


### PR DESCRIPTION
## What does this PR do?
Fixes #2338

This PR clears the payment methods list when the order mode is changed.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.