### PR TITLE
fix: correct exchange rate calculation for taken range orders

### DIFF
--- a/frontend/src/components/OrderDetails/index.tsx
+++ b/frontend/src/components/OrderDetails/index.tsx
@@ -196,7 +196,7 @@ const OrderDetails = ({
     const defaultRoutingBudget = 0.001;
     const btc_now = order.satoshis_now / 100000000;
     const rate =
-      (order.has_range && order.max_amount ? Number(order.max_amount) : Number(order.amount)) /
+      (order.amount && order.amount > 0 ? Number(order.amount) : Number(order.max_amount)) /
       btc_now;
 
     if (isBuyer) {


### PR DESCRIPTION
Fixes #2336

### Problem
For range orders, the "You receive" satoshi amount in the Order tab showed an incorrect (lower) value after the order was taken.

### Cause
The rate calculation used `max_amount` whenever `has_range` was true, even after the order was taken and `amount` was set to the actual taken value. This caused a math mismatch:
- `satoshis_now` was computed for the taken amount (eg 800 EUR)
- `rate` was computed incorrectly using `max_amount` (eg 1000 EUR)

### Fix
Changed the rate calculation to prioritize `order.amount` (the actual taken amount) when available. It falls back to `max_amount` only for untaken range orders.