### PR TITLE
fix: use 127.0.0.1 instead of localhost to match socat bindings

### DIFF
--- a/nodeapp/coordinators/alice/upstreams.conf
+++ b/nodeapp/coordinators/alice/upstreams.conf
@@ -1,9 +1,9 @@
 # Libre Bazaar Coordinator Mainnet
 upstream mainnet_alice {
-    server localhost:107;
+    server 127.0.0.1:107;
 }
 
 # Libre Bazaar Coordinator Testnet
 upstream testnet_alice {
-    server localhost:1007;
+    server 127.0.0.1:1007;
 }

--- a/nodeapp/coordinators/bazaar/upstreams.conf
+++ b/nodeapp/coordinators/bazaar/upstreams.conf
@@ -1,9 +1,9 @@
 # Libre Bazaar Coordinator Mainnet
 upstream mainnet_bazaar {
-    server localhost:107;
+    server 127.0.0.1:107;
 }
 
 # Libre Bazaar Coordinator Testnet
 upstream testnet_bazaar {
-    server localhost:1007;
+    server 127.0.0.1:1007;
 }

--- a/nodeapp/coordinators/freedomsats/upstreams.conf
+++ b/nodeapp/coordinators/freedomsats/upstreams.conf
@@ -1,9 +1,9 @@
 # Libre freedomsats Coordinator Mainnet
 upstream mainnet_freedomsats {
-    server localhost:108;
+    server 127.0.0.1:108;
 }
 
 # Libre freedomsats Coordinator Testnet
 upstream testnet_freedomsats {
-    server localhost:1008;
+    server 127.0.0.1:1008;
 }

--- a/nodeapp/coordinators/lake/upstreams.conf
+++ b/nodeapp/coordinators/lake/upstreams.conf
@@ -1,9 +1,9 @@
 # TheBigLake Coordinator Mainnet
 upstream mainnet_lake {
-    server localhost:104;
+    server 127.0.0.1:104;
 }
 
 # TheBigLake Coordinator Testnet
 upstream testnet_lake {
-    server localhost:1004;
+    server 127.0.0.1:1004;
 }

--- a/nodeapp/coordinators/moon/upstreams.conf
+++ b/nodeapp/coordinators/moon/upstreams.conf
@@ -1,9 +1,9 @@
 # Over the Moon Coordinator Mainnet
 upstream mainnet_moon {
-    server localhost:106;
+    server 127.0.0.1:106;
 }
 
 # Over the Moon Coordinator Testnet
 upstream testnet_moon {
-    server localhost:1006;
+    server 127.0.0.1:1006;
 }

--- a/nodeapp/coordinators/temple/upstreams.conf
+++ b/nodeapp/coordinators/temple/upstreams.conf
@@ -1,9 +1,9 @@
 # Temple of Sats Coordinator Mainnet
 upstream mainnet_temple {
-    server localhost:102;
+    server 127.0.0.1:102;
 }
 
 # Temple of Sats Coordinator Testnet
 upstream testnet_temple {
-    server localhost:1002;
+    server 127.0.0.1:1002;
 }

--- a/nodeapp/coordinators/veneto/upstreams.conf
+++ b/nodeapp/coordinators/veneto/upstreams.conf
@@ -1,9 +1,9 @@
 # BitcoinVeneto Coordinator Mainnet
 upstream mainnet_veneto {
-    server localhost:105;
+    server 127.0.0.1:105;
 }
 
 # BitcoinVeneto Coordinator Testnet
 upstream testnet_veneto {
-    server localhost:1005;
+    server 127.0.0.1:1005;
 }

--- a/nodeapp/coordinators/whiteyesats/upstreams.conf
+++ b/nodeapp/coordinators/whiteyesats/upstreams.conf
@@ -1,9 +1,9 @@
 # Libre Bazaar Coordinator Mainnet
 upstream mainnet_whiteyesats {
-    server localhost:107;
+    server 127.0.0.1:107;
 }
 
 # Libre Bazaar Coordinator Testnet
 upstream testnet_whiteyesats {
-    server localhost:1007;
+    server 127.0.0.1:1007;
 }


### PR DESCRIPTION
## What does this PR do?
This PR fixes an IPv6/IPv4 mismatch between NGINX upstreams and socat listeners used by [robosats-client.sh](https://github.com/RoboSats/robosats/blob/main/nodeapp/robosats-client.sh) . 
For context, see the failing [logs](https://pastebin.com/d2gu3Dmw)

NGINX upstreams were configured to use `localhost`, which resolves to `::1` (IPv6) inside Docker containers. However, `robosats-client.sh` binds all socat bridges explicitly to `127.0.0.1` (IPv4). This caused `connect() failed (111: Connection refused)` errors when NGINX attempted to connect over IPv6

The fix replaces `localhost` with `127.0.0.1` in all coordinator upstreams.conf files, ensuring NGINX connects to the correct IPv4 sockets exposed by socat. 
Final working logs after the fix can be found [here](https://pastebin.com/7J5h9hRW)
## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.