### PR TITLE
feat: display bond % stacked under premium on mobile

### DIFF
--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -410,14 +410,51 @@ const BookTable = ({
             title={`${pn(params.row.price)} ${currencyCode}/BTC`}
           >
             <div
-              style={{ cursor: 'pointer' }}
+              style={{
+                cursor: 'pointer',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'center',
+                alignItems: 'flex-end',
+                height: '100%',
+                width: '100%',
+                lineHeight: 1,
+              }}
               onClick={() => {
                 onOrderClicked(params.row.id, params.row.coordinatorShortAlias);
               }}
             >
-              <Typography variant='inherit' color={fontColor} sx={{ fontWeight }}>
+              <Typography
+                variant='inherit'
+                color={fontColor}
+                sx={{
+                  fontWeight,
+                  lineHeight: '1.2',
+                  fontSize: { xs: '0.9rem', md: 'inherit' },
+                  textAlign: 'right',
+                }}
+              >
                 {`${parseFloat(parseFloat(params.row.premium).toFixed(4))}%`}
               </Typography>
+              <Box
+                sx={{
+                  display: { xs: 'block', lg: 'none' },
+                  lineHeight: '1',
+                  marginTop: '2px',
+                }}
+              >
+                <Typography
+                  variant='caption'
+                  color='text.secondary'
+                  sx={{
+                    fontSize: '0.70rem',
+                    lineHeight: '1',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {params.row.bond_size ? `Bond: ${Number(params.row.bond_size)}%` : 'Bond: -'}
+                </Typography>
+              </Box>
             </div>
           </Tooltip>
         );


### PR DESCRIPTION
## What does this PR do?
Fixes #2349 

This PR implements the mobile UI improvement to display Bond %.
It stacks the Bond value under the Premium value on small screens.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.