### PR TITLE
Fix grammar in frontend locales

### DIFF
--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -958,7 +958,7 @@ const MakerForm = ({
                 enterTouchDelay={300}
                 enterDelay={700}
                 enterNextDelay={2000}
-                title={t('You can add a more details about your order.')}
+                title={t('You can add more details about your order.')}
               >
                 <TextField
                   fullWidth

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "La prima no és vàlida.",
   "The premium must be a number.": "La prima ha de ser un número.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Per protegir la teva privacitat, la ubicació exacta que fixis serà lleugerament aleatòria.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Has d'omplir el formulari correctament",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Reps aprox. {{swapSats}} LN Sats (les taxes poden variar)",

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Prémie není platná.",
   "The premium must be a number.": "Prémie musí být číslo.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "K ochraně vašeho soukromí bude přesná poloha, kterou umístíte, mírně náhodně upravena.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Musíte formulář správně vyplnit",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Obdržíte přibližně {{swapSats}} LN Sats (poplatky se mohou lišit)",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Das Premium ist ungültig.",
   "The premium must be a number.": "Das Premium muss eine Zahl sein.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Um deine Privatsphäre zu schützen, wird die exakte Position, die du anpinnst, leicht zufällig gewählt.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Du musst das Formular korrekt ausfüllen",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Du empfängst ungefähr {{swapSats}} LN Sats (Gebühren können variieren)",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "The premium is not valid.",
   "The premium must be a number.": "The premium must be a number.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "To protect your privacy, the exact location you pin will be slightly randomized.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "You must fill the form correctly",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "You receive approx {{swapSats}} LN Sats (fees might vary)",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "La prima no es válida.",
   "The premium must be a number.": "La prima debe ser un número.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Para proteger tu privacidad, la ubicación exacta que marcas se aleatorizará ligeramente.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Debes completar el formulario correctamente",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Recibes aproximadamente {{swapSats}} LN Sats (las comisiones pueden variar)",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Prima ez da baliozkoa.",
   "The premium must be a number.": "Primak zenbakia izan behar du.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Zure pribatutasuna babesteko, aukeratutako kokapen zehatza apur bat ausaz desbideratuta egongo da.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Inprimakia behar bezala bete behar duzu",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Gutxi gorabehera jasoko duzu {{swapSats}} LN Sats (komisioak aldatu daitezke)",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "La prime n'est pas valide.",
   "The premium must be a number.": "La prime doit être un nombre.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Pour protéger votre vie privée, l'emplacement exact que vous épinglez sera légèrement randomisé.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Vous devez remplir le formulaire correctement",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Vous recevez environ {{swapSats}} LN Sats (les frais peuvent varier).",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Il premio non è valido.",
   "The premium must be a number.": "Il premio deve essere un numero.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Per proteggere la tua privacy, la posizione esatta selezionata sarà leggermente randomizzata.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Devi compilare correttamente il modulo",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Ricevi circa {{swapSats}} LN Sats (le commissioni possono variare)",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "プレミアムが正しくありません。",
   "The premium must be a number.": "プレミアムは数値である必要があります。",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "プライバシーを保護するために、ピンをした正確な位置が多少ランダム化されます。",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "フォームに正しく入力する必要があります。",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "約{{swapSats}} ライトニングSatsを受け取ります（手数料は異なる場合があります）",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Premia jest nieprawidłowa.",
   "The premium must be a number.": "Premia musi być liczbą.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Aby chronić swoją prywatność, dokładna lokalizacja, którą zaznaczasz, będzie lekko zrandomizowana.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Musisz poprawnie wypełnić formularz",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Otrzymujesz około {{swapSats}} LN Sats (opłaty mogą się różnić)",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "O prémio não é válido.",
   "The premium must be a number.": "O prémio deve ser um número.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Para proteger sua privacidade, a localização exata que você marcar será ligeiramente aleatória.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Você deve preencher o formulário corretamente",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Você recebe aprox {{swapSats}} LN Sats (as taxas podem variar)",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Премия недействительна.",
   "The premium must be a number.": "Премия должна быть числом.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Чтобы защитить вашу конфиденциальность, точное местоположение, которое вы закрепите, будет слегка рандомизировано.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Вы должны правильно заполнить форму",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Вы получаете примерно {{swapSats}} LN Сатоши (комиссия может различаться)",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Premien är inte giltig.",
   "The premium must be a number.": "Premien måste vara ett tal.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "För att skydda din integritet kommer den exakta plats du markerar att vara något slumpmässig.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Du måste fylla i formuläret korrekt",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Du tar emot cirka {{swapSats}} LN Sats (avgifter kan variera)",

--- a/frontend/static/locales/sw.json
+++ b/frontend/static/locales/sw.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "Ziada si sahihi.",
   "The premium must be a number.": "Ziada lazima iwe namba.",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "Ili kulinda faragha yako, eneo halisi unaloweka litabadilishwa kuwa la nasibu.",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "Lazima ujaze fomu kwa usahihi",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "Unapokea takribani {{swapSats}} LN Sats (ada inaweza kutofautiana)",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "ค่าพรีเมียมไม่ถูกต้อง",
   "The premium must be a number.": "ค่าพรีเมียมต้องเป็นตัวเลข",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "เพื่อปกป้องความเป็นส่วนตัวของคุณ ตำแหน่งที่คุณปักจะถูกสุ่มใหม่",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "คุณต้องกรอกแบบฟอร์มอย่างถูกต้อง",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "คุณจะได้รับประมาณ {{swapSats}} LN Sats (ค่าธรรมเนียมอาจแตกต่างกัน)",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "溢价无效。",
   "The premium must be a number.": "溢价必须是一个数字。",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "为了保护您的隐私，您固定的确切位置将会稍微随机化。",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "您必须正确填写表格",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "你将接收大约{{swapSats}}闪电聪（费用会造成差异）",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -460,7 +460,7 @@
   "The premium is not valid.": "溢價無效。",
   "The premium must be a number.": "溢價必須是數字。",
   "To protect your privacy, the exact location you pin will be slightly randomized.": "為了保護您的隱私，您釘的確切位置將會被稍微隨機化。",
-  "You can add a more details about your order.": "You can add a more details about your order.",
+  "You can add more details about your order.": "You can add more details about your order.",
   "You can optionally set a password so that only the robots you share it with can take this order.": "You can optionally set a password so that only the robots you share it with can take this order.",
   "You must fill the form correctly": "您必須正確填寫表單",
   "You receive approx {{swapSats}} LN Sats (fees might vary)": "您將收到大約{{swapSats}} 閃電聰（費用可能有所不同）",


### PR DESCRIPTION
## What does this PR do?
Fixes a common grammar issue (superfluous `a`) across all frontend locale files

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.