### PR TITLE
escrow duration: increase from 8 hours to 10 hours

### DIFF
--- a/api/models/order.py
+++ b/api/models/order.py
@@ -125,7 +125,7 @@ class Order(models.Model):
         null=False,
         validators=[
             MinValueValidator(60 * 30),  # Min is 30 minutes
-            MaxValueValidator(60 * 60 * 8),  # Max is 8 Hours
+            MaxValueValidator(60 * 60 * 10),  # Max is 10 Hours
         ],
         blank=False,
     )

--- a/docs/_pages/docs/03-understand/05-trade-escrow.md
+++ b/docs/_pages/docs/03-understand/05-trade-escrow.md
@@ -12,7 +12,7 @@ src: "_pages/docs/03-understand/05-trade-escrow.md"
 
 When selling bitcoin, a trade escrow is used as an assurance of security. RoboSats leverages Lightning [hold invoices](https://github.com/lightningnetwork/lnd/pull/2022) in the escrow system to protect the buyer from fraud or nonpayment against their trading peer.
 
-The alotted time to pay (lock) a trade escrow is determined by the order maker. The escrow's expiry timer defaults to {{site.robosats.hours_submit_escrow}} hours; however, this can be customized to range anywhere from 1 to 8 hours.
+The alotted time to pay (lock) a trade escrow is determined by the order maker. The escrow's expiry timer defaults to {{site.robosats.hours_submit_escrow}} hours; however, this can be customized to range anywhere from 1 to 10 hours.
 
 If the seller fails to lock their trade escrow within the given time limit, then the seller forfeits their fidelity bond. Refer to [Understand > Bonds](/docs/bonds/) for additional information on fidelity bonds. In addition, if a dispute is opened, then the Satoshis in escrow are released to the dispute winner.
 
@@ -35,12 +35,12 @@ This method is, at the moment, the safest approach to ensuring peers hold up to 
 First, refer to [Understand > Wallets](/docs/wallets/) for compatible Lightning wallets that will help make using RoboSats a smoother experience. Depending on the wallet, the locked funds might show as a payment that is in transit, frozen, or even appearing to fail. Check the wallet compatability list!
 
 Read the relevant guide depending on if you are making or taking an order to sell bitcoin:
-* **Maker**: Create an order and modify the order conditions to your liking. The order can be customized to require an "Escrow/Invoice Timer" (expiry timer) other than the default of {{site.robosats.hours_submit_escrow}} hours, ranging anywhere from 1 to 8 hours. When your published order gets taken and the taker has submitted their fidelity bond, use the shown QR code with your Lightning wallet to lock the indicated amount of sats as collateral (escrow). *Note: Escrow funds are released to the buyer once you select "Confirm Fiat Received" which settles the order. Only confirm after the fiat has arrived in your account.*
+* **Maker**: Create an order and modify the order conditions to your liking. The order can be customized to require an "Escrow/Invoice Timer" (expiry timer) other than the default of {{site.robosats.hours_submit_escrow}} hours, ranging anywhere from 1 to 10 hours. When your published order gets taken and the taker has submitted their fidelity bond, use the shown QR code with your Lightning wallet to lock the indicated amount of sats as collateral (escrow). *Note: Escrow funds are released to the buyer once you select "Confirm Fiat Received" which settles the order. Only confirm after the fiat has arrived in your account.*
 * **Taker**: Browse the order book and find an order to your liking. Click "Take Order" and lock your fidelity bond. Immediately after submitting the bond, use the shown QR code with your Lightning wallet to lock the indicated amount of sats as collateral (escrow). *Note: Escrow funds are released to the buyer once you select "Confirm Fiat Received" which settles the order. Only confirm after the fiat has arrived in your account.*
 
 As soon as the order taker locks their bond, the buyer and seller are required to submit the payout invoice and trade escrow, respectively, within the given time limit.
 
-By default, the expiry timer is {{site.robosats.hours_submit_escrow}} hours; however, as the order maker, you can customize the timer to be anywhere from 1 hour to 8 hours. In other words, modify the time allowed to lock the escrow funds and provide the payout invoice. Maybe you want an expedited transaction and will set the timer to a maximum of 1 hour instead of {{site.robosats.hours_submit_escrow}} hours.
+By default, the expiry timer is {{site.robosats.hours_submit_escrow}} hours; however, as the order maker, you can customize the timer to be anywhere from 1 hour to 10 hours. In other words, modify the time allowed to lock the escrow funds and provide the payout invoice. Maybe you want an expedited transaction and will set the timer to a maximum of 1 hour instead of {{site.robosats.hours_submit_escrow}} hours.
 
 If the seller locks the escrow funds before the buyer has provided the payout invoice, then the seller waits to enter the peer-to-peer chat stage until after the buyer has provided their invoice.
 

--- a/docs/assets/schemas/api-latest.yaml
+++ b/docs/assets/schemas/api-latest.yaml
@@ -1272,7 +1272,7 @@ components:
           nullable: true
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         bond_size:
           type: string
@@ -1355,7 +1355,7 @@ components:
           minimum: 597.6
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         bond_size:
           type: string
@@ -1469,7 +1469,7 @@ components:
           nullable: true
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         total_secs_exp:
           type: integer
@@ -1772,7 +1772,7 @@ components:
           description: Price in order's fiat currency
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         satoshis_now:
           type: integer

--- a/docs/assets/schemas/api-v0.1.yaml
+++ b/docs/assets/schemas/api-v0.1.yaml
@@ -1096,7 +1096,7 @@ components:
           nullable: true
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         bond_size:
           type: string
@@ -1169,7 +1169,7 @@ components:
           minimum: 597.6
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         bond_size:
           type: string
@@ -1272,7 +1272,7 @@ components:
           nullable: true
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         total_secs_exp:
           type: integer
@@ -1545,7 +1545,7 @@ components:
           description: Price in order's fiat currency
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
       required:
       - expires_at

--- a/docs/assets/schemas/api-v0.5.3.yaml
+++ b/docs/assets/schemas/api-v0.5.3.yaml
@@ -1235,7 +1235,7 @@ components:
           nullable: true
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         bond_size:
           type: string
@@ -1318,7 +1318,7 @@ components:
           minimum: 597.6
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         bond_size:
           type: string
@@ -1439,7 +1439,7 @@ components:
           nullable: true
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         total_secs_exp:
           type: integer
@@ -1719,7 +1719,7 @@ components:
           description: Price in order's fiat currency
         escrow_duration:
           type: integer
-          maximum: 28800
+          maximum: 36000
           minimum: 1800
         satoshis_now:
           type: integer

--- a/frontend/src/components/MakerForm/MakerForm.tsx
+++ b/frontend/src/components/MakerForm/MakerForm.tsx
@@ -1071,7 +1071,7 @@ const MakerForm = ({
                   value={maker.escrowExpiryTime}
                   onChange={handleChangeEscrowDuration}
                   minTime={new Date(0, 0, 0, 1, 0)}
-                  maxTime={new Date(0, 0, 0, 8, 0)}
+                  maxTime={new Date(0, 0, 0, 10, 0)}
                 />
               </LocalizationProvider>
             </Grid>

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -267,7 +267,7 @@ class TradeTest(BaseAPITestCase):
                 "is_explicit": False,
                 "premium": 3.34,
                 "public_duration": 69360,
-                "escrow_duration": 8700,
+                "escrow_duration": 36000,
                 "bond_size": 3.5,
                 "latitude": -11.8014,  # Angola AGO
                 "longitude": 17.3575,

--- a/tests/utils/trade.py
+++ b/tests/utils/trade.py
@@ -25,7 +25,7 @@ maker_form_buy_with_range = {
     "is_explicit": False,
     "premium": 3.34,
     "public_duration": 69360,
-    "escrow_duration": 8700,
+    "escrow_duration": 36000,
     "bond_size": 3.5,
     "latitude": 34.7455,
     "longitude": 135.503,


### PR DESCRIPTION
## What does this PR do?
This PR increases the escrow duration from 8 hours to 10 hours with changes suggested by KoalaSat 

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.