### PR TITLE
Fix: Sync coordinator ratings between list and detail views

### DIFF
--- a/frontend/src/services/RoboPool/index.ts
+++ b/frontend/src/services/RoboPool/index.ts
@@ -129,25 +129,25 @@ class RoboPool {
     this.sendMessage(JSON.stringify(requestBook));
   };
 
-  subscribeRatings = (events: RoboPoolEvents, pubkeys?: string[], id?: string): void => {
+  subscribeRatings = (events: RoboPoolEvents, pubkeys?: string[], id?: string): string => {
     const pubkeysFilter =
       pubkeys ??
       Object.values(defaultFederation)
         .map((f) => f.nostrHexPubkey)
         .filter((item) => item !== undefined);
 
-    const subscribeRatings = `subscribeRatings${id ?? ''}`;
+    const subscriptionId = `subscribeRatings${id ?? ''}`;
     const sixMonthsAgo = Math.floor(new Date().getTime() / 1000) - 6 * 30 * 24 * 60 * 60;
     const requestRatings = [
       'REQ',
-      subscribeRatings,
+      subscriptionId,
       { kinds: [31986], '#p': pubkeysFilter, since: sixMonthsAgo },
     ];
 
     this.messageHandlers.push((_url: string, messageEvent: MessageEvent) => {
       const jsonMessage = JSON.parse(messageEvent.data);
 
-      if (subscribeRatings !== jsonMessage[1]) return;
+      if (subscriptionId !== jsonMessage[1]) return;
 
       if (jsonMessage[0] === 'EVENT') {
         events.onevent(jsonMessage[2]);
@@ -156,6 +156,12 @@ class RoboPool {
       }
     });
     this.sendMessage(JSON.stringify(requestRatings));
+
+    return subscriptionId;
+  };
+
+  closeSubscription = (subscriptionId: string): void => {
+    this.sendMessage(JSON.stringify(['CLOSE', subscriptionId]));
   };
 
   subscribeNotifications = (garage: Garage, events: RoboPoolEvents): void => {

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias already exists",
   "Enabled": "Habilitat",
   "Invalid Onion URL": "Invalid Onion URL",
-  "Invalid ratings have been filtered.": "Invalid ratings have been filtered.",
   "No coordinators found.": "No s'han trobat coordinadors.",
   "Rating": "Rating",
   "Reloading. Invalid ratings will be filtered.": "Reloading. Invalid ratings will be filtered.",

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Přezdívka již existuje",
   "Enabled": "Povoleno",
   "Invalid Onion URL": "Neplatná Onion URL",
-  "Invalid ratings have been filtered.": "Neplatná hodnocení byla odfiltrována.",
   "No coordinators found.": "Nenalezeni žádní koordinátoři.",
   "Rating": "Hodnocení",
   "Reloading. Invalid ratings will be filtered.": "Načítání znovu. Neplatná hodnocení budou odfiltrována.",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias existiert bereits",
   "Enabled": "Aktiviert",
   "Invalid Onion URL": "Ungültige Onion-URL",
-  "Invalid ratings have been filtered.": "Ungültige Bewertungen wurden gefiltert.",
   "No coordinators found.": "Keine Koordinatoren gefunden.",
   "Rating": "Bewertung",
   "Reloading. Invalid ratings will be filtered.": "Neu laden. Ungültige Bewertungen werden gefiltert.",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias already exists",
   "Enabled": "Enabled",
   "Invalid Onion URL": "Invalid Onion URL",
-  "Invalid ratings have been filtered.": "Invalid ratings have been filtered.",
   "No coordinators found.": "No coordinators found.",
   "Rating": "Rating",
   "Reloading. Invalid ratings will be filtered.": "Reloading. Invalid ratings will be filtered.",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias ya existe",
   "Enabled": "Habilitado",
   "Invalid Onion URL": "URL Onion inválida",
-  "Invalid ratings have been filtered.": "Las calificaciones inválidas han sido filtradas.",
   "No coordinators found.": "No se encontraron coordinadores.",
   "Rating": "Calificación",
   "Reloading. Invalid ratings will be filtered.": "Recargando. Las calificaciones inválidas serán filtradas.",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias dagoeneko existitzen da",
   "Enabled": "Gaitua",
   "Invalid Onion URL": "Onion ULR baliogabea",
-  "Invalid ratings have been filtered.": "Balorazio baliogabeak iragazi dira.",
   "No coordinators found.": "Ez da koordinatzailerik aurkitu.",
   "Rating": "Balorazioa",
   "Reloading. Invalid ratings will be filtered.": "Berrikarga. Balorazio baliogabeak iragaziko dira.",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias existe déjà",
   "Enabled": "Activé",
   "Invalid Onion URL": "URL Onion invalide",
-  "Invalid ratings have been filtered.": "Les évaluations invalides ont été filtrées.",
   "No coordinators found.": "Aucun coordinateur trouvé.",
   "Rating": "Évaluation",
   "Reloading. Invalid ratings will be filtered.": "Rechargement. Les évaluations invalides seront filtrées.",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias già esistente",
   "Enabled": "Abilitato",
   "Invalid Onion URL": "URL Onion invalido",
-  "Invalid ratings have been filtered.": "Le valutazioni non valide sono state filtrate.",
   "No coordinators found.": "Nessun coordinatore trovato.",
   "Rating": "Valutazione",
   "Reloading. Invalid ratings will be filtered.": "Ricaricamento. Le valutazioni non valide saranno filtrate.",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -387,7 +387,6 @@
   "Alias already exists": "エイリアスはすでに存在します",
   "Enabled": "有効",
   "Invalid Onion URL": "無効なOnion URL",
-  "Invalid ratings have been filtered.": "無効な評価がフィルタリングされました。",
   "No coordinators found.": "コーディネーターが見つかりませんでした。",
   "Rating": "評価",
   "Reloading. Invalid ratings will be filtered.": "再読み込み中。無効な評価はフィルタリングされます。",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias już istnieje",
   "Enabled": "Włączony",
   "Invalid Onion URL": "Nieprawidłowy adres Onion",
-  "Invalid ratings have been filtered.": "Nieprawidłowe oceny zostały odfiltrowane.",
   "No coordinators found.": "Nie znaleziono koordynatorów.",
   "Rating": "Ocena",
   "Reloading. Invalid ratings will be filtered.": "Przeładowywanie. Nieprawidłowe oceny zostaną odfiltrowane.",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias já existe",
   "Enabled": "Habilitado",
   "Invalid Onion URL": "URL Onion Inválida",
-  "Invalid ratings have been filtered.": "Avaliações inválidas foram filtradas.",
   "No coordinators found.": "Nenhum coordenador encontrado.",
   "Rating": "Avaliação",
   "Reloading. Invalid ratings will be filtered.": "Recarregando. Avaliações inválidas serão filtradas.",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Псевдоним уже существует",
   "Enabled": "Включено",
   "Invalid Onion URL": "Недействительный URL Onion",
-  "Invalid ratings have been filtered.": "Недопустимые рейтинги были отфильтрованы.",
   "No coordinators found.": "Координаторы не найдены.",
   "Rating": "Рейтинг",
   "Reloading. Invalid ratings will be filtered.": "Перезагрузка. Недопустимые рейтинги будут отфильтрованы.",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Alias finns redan",
   "Enabled": "Aktiverad",
   "Invalid Onion URL": "Ogiltig Onion URL",
-  "Invalid ratings have been filtered.": "Ogiltiga betyg har filtrerats.",
   "No coordinators found.": "Inga samordnare hittades.",
   "Rating": "Betyg",
   "Reloading. Invalid ratings will be filtered.": "Laddar om. Ogiltiga betyg kommer att filtreras.",

--- a/frontend/static/locales/sw.json
+++ b/frontend/static/locales/sw.json
@@ -387,7 +387,6 @@
   "Alias already exists": "Taaluma tayari ipo",
   "Enabled": "Imewashwa",
   "Invalid Onion URL": "URL ya Onion si sahihi",
-  "Invalid ratings have been filtered.": "Rating ambazo si sahihi zimetengwa.",
   "No coordinators found.": "Hakuna waandaaji waliopatikana.",
   "Rating": "Rating",
   "Reloading. Invalid ratings will be filtered.": "Inapakia upya. Rating ambazo si sahihi zitatengwa.",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -387,7 +387,6 @@
   "Alias already exists": "มีนามแฝงอยู่แล้ว",
   "Enabled": "เปิดการใช้งาน",
   "Invalid Onion URL": "URL ของ Onion ไม่ถูกต้อง",
-  "Invalid ratings have been filtered.": "การจัดอันดับที่ไม่ถูกต้องได้รับการกรอง",
   "No coordinators found.": "ไม่พบผู้ประสานงาน",
   "Rating": "การจัดอันดับ",
   "Reloading. Invalid ratings will be filtered.": "กำลังโหลดใหม่ การจัดอันดับที่ไม่ถูกต้องจะได้รับการกรอง",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -387,7 +387,6 @@
   "Alias already exists": "别名已存在",
   "Enabled": "已启用",
   "Invalid Onion URL": "无效的洋葱URL",
-  "Invalid ratings have been filtered.": "无效评分已过滤。",
   "No coordinators found.": "未找到协调员。",
   "Rating": "评分",
   "Reloading. Invalid ratings will be filtered.": "重新加载。无效评分将被筛选。",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -387,7 +387,6 @@
   "Alias already exists": "別名已存在",
   "Enabled": "已啟用",
   "Invalid Onion URL": "無效的 Onion URL",
-  "Invalid ratings have been filtered.": "無效評級已被篩選。",
   "No coordinators found.": "未找到協調者。",
   "Rating": "評級",
   "Reloading. Invalid ratings will be filtered.": "重新加載。 無效評級將被篩選。",


### PR DESCRIPTION
## What does this PR do?
Fixes #2380

This PR introduces/refactors/...
 fixes issue where coordinator ratings showed different counts in the list view vs. the detail dialog.
Problem: Each view had its own separate state for ratings, causing inconsistencies.
Fix: Moved ratings into `Federation.model.ts` so both views share the same data.
Happy to make any changes if needed.
<img width="1074" height="682" alt="Screenshot 2026-01-18 at 7 25 38 PM" src="https://github.com/user-attachments/assets/aa8b6f2d-d807-434d-9e36-1868736bc01c" />
<img width="905" height="788" alt="Screenshot 2026-01-18 at 7 25 59 PM" src="https://github.com/user-attachments/assets/f9ac075c-72d3-4629-be5b-e9c7569547fa" />

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.