### PR TITLE
fix: synchronize bond column visibility with premium column bond info display

### DIFF
--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -473,8 +473,6 @@ const BookTable = ({
           </span>
         );
 
-        const hasBondCol = !!params.api.getColumn('bond_size');
-
         return (
           <Tooltip placement='left' enterTouchDelay={0} title={tooltipTitle}>
             <div


### PR DESCRIPTION
## What does this PR do?

Fixes a UI overlap issue where the bond percentage was displayed simultaneously in both the Bond column and the Premium column on certain screen sizes. This issue was caused by this [line](https://github.com/RoboSats/robosats/blob/main/frontend/src/components/BookTable/index.tsx#L504) which uses a hardcoded MUI `lg` breakpoint. The image below demonstrates the issue:

<img width="905" height="527" alt="image" src="https://github.com/user-attachments/assets/9b2496ae-389e-49af-a347-5e7724e055c5" />


This PR replaces the hardcoded MUI breakpoint with a dynamic visibility check that monitors which columns are actually rendered.

After applying the changes:
<img width="906" height="473" alt="image" src="https://github.com/user-attachments/assets/dbd1beca-1dfb-4ba0-a7a9-14e290c48052" />
## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.