### PR TITLE
Fix: resolve crash on mobile when switching between Fiat and Swap modes

### DIFF
--- a/frontend/src/components/BookTable/BookControl.tsx
+++ b/frontend/src/components/BookTable/BookControl.tsx
@@ -306,8 +306,9 @@ const BookControl = ({
                     <CheckBoxOutlineBlankIcon style={{ position: 'relative', top: '0.1em' }} />
                   );
                 } else {
-                  const methods = fav.currency === 1000 ? swapMethods : fiatMethods;
+                  const methods = fav.mode === 'swap' ? swapMethods : fiatMethods;
                   const method = methods.find((m) => m.name === value);
+                  if (!method) return null;
                   return (
                     <div style={{ display: 'flex', alignItems: 'center' }}>
                       <PaymentIcon width={22} height={22} icon={method.icon} />
@@ -332,7 +333,7 @@ const BookControl = ({
                   </Typography>
                 </div>
               </MenuItem>
-              {fav.currency === 1000
+              {fav.mode === 'swap'
                 ? swapMethods.map((method, index) => (
                     <MenuItem
                       style={{ width: '10em' }}

--- a/frontend/src/components/BookTable/index.tsx
+++ b/frontend/src/components/BookTable/index.tsx
@@ -117,6 +117,10 @@ const BookTable = ({
     });
   }, [defaultPageSize]);
 
+  useEffect(() => {
+    setPaymentMethods([]);
+  }, [fav.mode]);
+
   const localeText = useMemo(() => {
     return {
       noResultsOverlayLabel: t('No results found.'),


### PR DESCRIPTION
## What does this PR do?
Fixes #2393 

This PR introduces/refactors/...

Fixes a crash on mobile devices when switching between Fiat/Swap modes with a payment method selected.


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.