### PR TITLE
Fix order page load

### DIFF
--- a/frontend/webpack.config.ts
+++ b/frontend/webpack.config.ts
@@ -54,7 +54,7 @@ const configNode = (env: any, argv: { mode: string }): Configuration => {
     plugins: [
       // Django
       new HtmlWebpackPlugin({
-        publicPath: './static/frontend/',
+        publicPath: '/static/frontend/',
         template: path.resolve(__dirname, 'templates/frontend/index.ejs'),
         templateParameters: {
           pro: false,
@@ -66,7 +66,7 @@ const configNode = (env: any, argv: { mode: string }): Configuration => {
         basePath: '/',
       }),
       new HtmlWebpackPlugin({
-        publicPath: './static/frontend/',
+        publicPath: '/static/frontend/',
         template: path.resolve(__dirname, 'templates/frontend/index.ejs'),
         templateParameters: {
           pro: true,
@@ -79,7 +79,7 @@ const configNode = (env: any, argv: { mode: string }): Configuration => {
       }),
       // Node App
       new HtmlWebpackPlugin({
-        publicPath: './static/frontend/',
+        publicPath: '/static/frontend/',
         template: path.resolve(__dirname, 'templates/frontend/index.ejs'),
         templateParameters: {
           pro: false,
@@ -91,7 +91,7 @@ const configNode = (env: any, argv: { mode: string }): Configuration => {
         basePath: '/',
       }),
       new HtmlWebpackPlugin({
-        publicPath: './static/frontend/',
+        publicPath: '/static/frontend/',
         template: path.resolve(__dirname, 'templates/frontend/index.ejs'),
         templateParameters: {
           pro: true,
@@ -119,7 +119,7 @@ const configNode = (env: any, argv: { mode: string }): Configuration => {
 
       // Web App
       new HtmlWebpackPlugin({
-        publicPath: './static/frontend/',
+        publicPath: '/static/frontend/',
         template: path.resolve(__dirname, 'templates/frontend/index.ejs'),
         templateParameters: {
           pro: false,
@@ -131,7 +131,7 @@ const configNode = (env: any, argv: { mode: string }): Configuration => {
         basePath: '/',
       }),
       new HtmlWebpackPlugin({
-        publicPath: './static/frontend/',
+        publicPath: '/static/frontend/',
         template: path.resolve(__dirname, 'templates/frontend/index.ejs'),
         templateParameters: {
           pro: true,


### PR DESCRIPTION
## What does this PR do?

When loading any specific path different from root (ex. http://localhost:8888/order/temple/71462) the app fails.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.