### PR TITLE
fix: resolve order page loading race condn

### DIFF
--- a/frontend/src/basic/OrderPage/index.tsx
+++ b/frontend/src/basic/OrderPage/index.tsx
@@ -25,8 +25,14 @@ import { type UseGarageStoreType, GarageContext } from '../../contexts/GarageCon
 import { genBase62Token } from '../../utils';
 
 const OrderPage = (): React.JSX.Element => {
-  const { windowSize, setOpen, acknowledgedWarning, setAcknowledgedWarning, navbarHeight } =
-    useContext<UseAppStoreType>(AppContext);
+  const {
+    windowSize,
+    setOpen,
+    acknowledgedWarning,
+    setAcknowledgedWarning,
+    navbarHeight,
+    slotUpdatedAt,
+  } = useContext<UseAppStoreType>(AppContext);
   const { federation } = useContext<UseFederationStoreType>(FederationContext);
   const { garage } = useContext<UseGarageStoreType>(GarageContext);
   const { t } = useTranslation();
@@ -63,7 +69,7 @@ const OrderPage = (): React.JSX.Element => {
     return () => {
       setCurrentOrder(null);
     };
-  }, [params.orderId, openNoRobot, garage.currentSlot]);
+  }, [params.orderId, openNoRobot, garage.currentSlot, slotUpdatedAt]);
 
   useEffect(() => {
     if (!currentOrder) return;


### PR DESCRIPTION
## What does this PR do?
Fixes #2400

This PR introduces/refactors/...
added `slotUpdatedAt` to the OrderPage's dependency array. This ensures the order fetch is automatically retried once the robot's data is fully loaded and auth headers are available.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.