### PR TITLE
fix: use BTC axis label instead of ₿ symbol in depth chart for Tor Browser compatibility

### DIFF
--- a/frontend/src/components/Charts/DepthChart/index.tsx
+++ b/frontend/src/components/Charts/DepthChart/index.tsx
@@ -276,7 +276,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
       return `${value}%`;
     }
   };
-  const formatAxisY = (value: number): string => `${value}₿`;
+  const formatAxisY = (value: number): string => `${value}`;
   const handleOnClick: PointMouseHandler = (point: Point) => {
     onOrderClicked(point.data?.order?.id, point.data?.order?.coordinatorShortAlias);
   };
@@ -384,6 +384,9 @@ const DepthChart: React.FC<DepthChartProps> = ({
                 axisLeft={{
                   tickSize: 5,
                   format: formatAxisY,
+                  legend: 'BTC',
+                  legendOffset: -42,
+                  legendPosition: 'middle',
                 }}
                 axisBottom={{
                   tickSize: 5,
@@ -392,7 +395,7 @@ const DepthChart: React.FC<DepthChartProps> = ({
                   format: formatAxisX,
                 }}
                 margin={{
-                  left: 3 * em,
+                  left: 3.5 * em,
                   right: 0.714 * em,
                   bottom:
                     xType === 'base_price'


### PR DESCRIPTION


## What does this PR do?
Fixes #2399 

This PR introduces/refactors/...

Replaces the ₿ symbol (not rendered in Tor Browser) with a "BTC" Y-axis label in the depth chart.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.