### PR TITLE
fix: prevent satoshis_now overwrite in OrderView

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -289,7 +289,15 @@ class OrderView(viewsets.ViewSet):
         data["longitude"] = order.longitude
         data["is_disputed"] = order.is_disputed
         data["ur_nick"] = request.user.username
-        data["satoshis_now"] = order.last_satoshis
+
+        # Use order.last_satoshis except when there's a take_order with a specific amount
+        # (in that case, satoshis_now was already calculated correctly above using take_order.amount)
+        if not (
+            take_order.exists()
+            and order.status >= Order.Status.PUB
+            and order.status < Order.Status.WF2
+        ):
+            data["satoshis_now"] = order.last_satoshis
 
         # Add whether hold invoices are LOCKED (ACCEPTED)
         # Is there a maker bond? If so, True if locked, False otherwise


### PR DESCRIPTION
## What does this PR do?
Fixes #2412

This PR fixes a bug in `api/views.py` where the satoshis_now value was being unconditionally overwritten by order.last_satoshis at the end of the OrderView processing.


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.