### PR TITLE
fix(api): return 200 with [] for empty /api/book

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -752,11 +752,8 @@ class BookView(ListAPIView):
                 currency=currency, type=type, status=Order.Status.PUB
             )
 
-        if len(queryset) == 0:
-            return Response(
-                {"not_found": "No orders found, be the first to make one"},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+        if not queryset.exists():
+            return Response([], status=status.HTTP_200_OK)
 
         book_data = []
         for order in queryset:

--- a/frontend/src/models/Coordinator.model.ts
+++ b/frontend/src/models/Coordinator.model.ts
@@ -196,16 +196,13 @@ export class Coordinator {
     apiClient
       .get(this.url, `/api/book/`, undefined, true)
       .then((data) => {
-        if (!data?.not_found) {
-          this.book = (data as PublicOrder[]).reduce<Record<string, PublicOrder>>((book, order) => {
-            order.coordinatorShortAlias = this.shortAlias;
-            return { ...book, [`${this.shortAlias}${order.id}`]: order };
-          }, {});
-          void this.generateAllMakerAvatars();
-          onDataLoad();
-        } else {
-          onDataLoad();
-        }
+        const orders = Array.isArray(data) ? data : [];
+        this.book = orders.reduce<Record<string, PublicOrder>>((book, order) => {
+          order.coordinatorShortAlias = this.shortAlias;
+          return { ...book, [`${this.shortAlias}${order.id}`]: order };
+        }, {});
+        void this.generateAllMakerAvatars();
+        onDataLoad();
       })
       .catch((e) => {
         console.log(e);

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -2019,6 +2019,18 @@ class TradeTest(BaseAPITestCase):
         # Cancel order to avoid leaving pending HTLCs after a successful test
         trade.cancel_order()
 
+    def test_book_empty(self):
+        """
+        Tests public book view when there are no public orders.
+        """
+        path = reverse("book")
+
+        response = self.client.get(path)
+        data = response.json()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data, [])
+
     def test_robot_creation_with_valid_nostr_pubkey(self):
         """
         Test that a robot can be created with a valid 64-character hex nostr pubkey.


### PR DESCRIPTION
Fixes #2416.

## Summary
- Change `/api/book` empty-result behavior from `404` with error payload to `200` with `[]`.
- Keep the existing successful response shape unchanged when public orders exist.
- Add a regression test for the empty book case.

## Changes
- `api/views.py`
  - `BookView.get`: return `Response([], status=200)` when no public orders match filters.
- `tests/test_trade_pipeline.py`
  - Add `test_book_empty` to assert `200` and empty list response.

## Validation
- `python -m py_compile api/views.py tests/test_trade_pipeline.py`

I attempted to run the Django test target for `test_book`/`test_book_empty`, but full runtime dependency setup in this environment required long native builds (`grpcio` and others) and could not be completed within this run.
