### PR TITLE
feat: persist book filters and decouple maker form state

### DIFF
--- a/frontend/src/basic/MakerPage/index.tsx
+++ b/frontend/src/basic/MakerPage/index.tsx
@@ -16,7 +16,7 @@ import VisitThirdParty from '../../components/Dialogs/VisitThirdParty';
 import { type PublicOrder } from '../../models';
 
 const MakerPage = (): React.JSX.Element => {
-  const { fav, windowSize, navbarHeight, navigateToPage } = useContext<UseAppStoreType>(AppContext);
+  const { windowSize, navbarHeight, navigateToPage } = useContext<UseAppStoreType>(AppContext);
   const { federation } = useContext<UseFederationStoreType>(FederationContext);
   const { garage, maker } = useContext<UseGarageStoreType>(GarageContext);
   const { t } = useTranslation();
@@ -34,9 +34,9 @@ const MakerPage = (): React.JSX.Element => {
     return filterOrders({
       federation,
       baseFilter: {
-        currency: fav.currency === 0 ? 1 : fav.currency,
-        type: fav.type,
-        mode: fav.mode,
+        currency: maker.currency === 0 ? 1 : maker.currency,
+        type: maker.type,
+        mode: maker.mode,
         coordinator: 'robosats',
       },
       premium: maker.premium ?? null,
@@ -50,7 +50,9 @@ const MakerPage = (): React.JSX.Element => {
     });
   }, [
     federation.book,
-    fav,
+    maker.currency,
+    maker.type,
+    maker.mode,
     maker.premium,
     maker.amount,
     maker.minAmount,

--- a/frontend/src/hooks/useBondEstimate.ts
+++ b/frontend/src/hooks/useBondEstimate.ts
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 import { calculateBondAmount } from '../utils/bondCalculator';
-import { Maker, Federation, Favorites } from '../models';
+import type { Maker, Federation } from '../models';
 
 interface UseBondEstimateProps {
   maker: Maker;
-  fav: Favorites;
   federation: Federation;
   currentPrice?: number;
   federationUpdatedAt: number;
@@ -13,7 +12,6 @@ interface UseBondEstimateProps {
 
 export const useBondEstimate = ({
   maker,
-  fav,
   federation,
   currentPrice,
   federationUpdatedAt,
@@ -33,7 +31,7 @@ export const useBondEstimate = ({
       maxAmount: maker.maxAmount,
       isRange: makerHasAmountRange,
       bondSize: bondPercentage,
-      mode: fav.mode as 'fiat' | 'swap',
+      mode: maker.mode,
       price: currentPrice ?? 0,
       premium: maker.premium ?? 0,
     });
@@ -45,7 +43,7 @@ export const useBondEstimate = ({
     maker.bondSize,
     maker.premium,
     currentPrice,
-    fav.mode,
+    maker.mode,
     maker.coordinator,
     federationUpdatedAt,
   ]);

--- a/frontend/src/models/Maker.model.ts
+++ b/frontend/src/models/Maker.model.ts
@@ -1,6 +1,9 @@
 import defaultFederation from '../../static/federation.json';
 
 export interface Maker {
+  type: number | null;
+  currency: number;
+  mode: 'swap' | 'fiat';
   advancedOptions: boolean;
   coordinator: string;
   isExplicit: boolean;
@@ -27,6 +30,9 @@ export interface Maker {
 }
 
 export const defaultMaker: Maker = {
+  type: null,
+  currency: 0,
+  mode: 'fiat',
   advancedOptions: false,
   coordinator:
     Object.keys(defaultFederation)[

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -417,7 +417,6 @@
   "Description": "Description",
   "Edit order": "Editar ordre",
   "Enable advanced options": "Habilitar opcions avançades",
-  "Enter the destination of the Lightning swap": "Introduïu l'adreça destí de l'intercanvi Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Temporitzador Dipòsit/Factura(HH:mm)",
   "Escrow/invoice step length": "Longitud passos Dipòsit/Factura",
   "Estimated Bond": "Fiança estimada",

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -417,7 +417,6 @@
   "Description": "Popis",
   "Edit order": "Upravit objednávku",
   "Enable advanced options": "Povolit pokročilé možnosti",
-  "Enter the destination of the Lightning swap": "Zadejte cíl Lightning výměny",
   "Escrow/Invoice Timer (HH:mm)": "Časovač úschovy faktury (HH:mm)",
   "Escrow/invoice step length": "Délka kroku úschovy faktury",
   "Estimated Bond": "Odhadovaná kauce",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -417,7 +417,6 @@
   "Description": "Beschreibung",
   "Edit order": "Bestellung bearbeiten",
   "Enable advanced options": "Erweiterte Optionen aktivieren",
-  "Enter the destination of the Lightning swap": "Gib das Ziel des Lightning-Swaps ein",
   "Escrow/Invoice Timer (HH:mm)": "Escrow/Rechnungstimer (HH:mm)",
   "Escrow/invoice step length": "Escrow/Rechnungsschrittlänge",
   "Estimated Bond": "Geschätzte Kaution",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -417,7 +417,6 @@
   "Description": "Description",
   "Edit order": "Edit order",
   "Enable advanced options": "Enable advanced options",
-  "Enter the destination of the Lightning swap": "Enter the destination of the Lightning swap",
   "Escrow/Invoice Timer (HH:mm)": "Escrow/Invoice Timer (HH:mm)",
   "Escrow/invoice step length": "Escrow/invoice step length",
   "Estimated Bond": "Estimated Bond",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -417,7 +417,6 @@
   "Description": "Descripción",
   "Edit order": "Editar orden",
   "Enable advanced options": "Activar opciones avanzadas",
-  "Enter the destination of the Lightning swap": "Indique el destino del intercambio Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Plazo depósito/factura (HH:mm)",
   "Escrow/invoice step length": "Longitud del paso de depósito/factura",
   "Estimated Bond": "Fianza estimada",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -417,7 +417,6 @@
   "Description": "Deskribapena",
   "Edit order": "Editatu eskaera",
   "Enable advanced options": "Gaitu aukera aurreratuak",
-  "Enter the destination of the Lightning swap": "Sartu Lightning trukearen helmuga",
   "Escrow/Invoice Timer (HH:mm)": "Eskrow/Factura Tenporizadorea (HH:mm)",
   "Escrow/invoice step length": "Eskrow/faktura urratsaren luzera",
   "Estimated Bond": "Fidantza estimatua",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -417,7 +417,6 @@
   "Description": "Description",
   "Edit order": "Modifier l'ordre",
   "Enable advanced options": "Activer les options avancées",
-  "Enter the destination of the Lightning swap": "Saisir la destination de l'échange Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Minuterie de dépôt de garantie/facture (HH:mm)",
   "Escrow/invoice step length": "Longueur de l'étape de dépôt fiduciaire/facture",
   "Estimated Bond": "Caution estimée",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -417,7 +417,6 @@
   "Description": "Descrizione",
   "Edit order": "Modifica ordine",
   "Enable advanced options": "Abilita opzioni avanzate",
-  "Enter the destination of the Lightning swap": "Inserisci la destinazione dello swap Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Timer Escrow/Fattura (HH:mm)",
   "Escrow/invoice step length": "Lunghezza passaggio Escrow/fattura",
   "Estimated Bond": "Cauzione stimata",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -417,7 +417,6 @@
   "Description": "説明",
   "Edit order": "注文を編集",
   "Enable advanced options": "高度な設定を有効にする",
-  "Enter the destination of the Lightning swap": "ライトニングスワップの送信先を入力してください。",
   "Escrow/Invoice Timer (HH:mm)": "エスクロー/インボイスのタイマー(HH:mm)",
   "Escrow/invoice step length": "エスクロー/インボイスのステップ期間",
   "Estimated Bond": "推定保証金",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -417,7 +417,6 @@
   "Description": "Opis",
   "Edit order": "Edytuj zamówienie",
   "Enable advanced options": "Włącz zaawansowane opcje",
-  "Enter the destination of the Lightning swap": "Wprowadź cel wymiany Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Timer Escrow/Faktura (HH:mm)",
   "Escrow/invoice step length": "Długość kroku escrow/faktura",
   "Estimated Bond": "Szacowana kaucja",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -417,7 +417,6 @@
   "Description": "Descrição",
   "Edit order": "Editar ordem",
   "Enable advanced options": "Habilitar opções avançadas",
-  "Enter the destination of the Lightning swap": "Insira o destino do swap Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Temporizador de Caução/Invoice (HH:mm)",
   "Escrow/invoice step length": "Comprimento da etapa de caução/invoice",
   "Estimated Bond": "Fiança estimada",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -417,7 +417,6 @@
   "Description": "Описание",
   "Edit order": "Изменить ордер",
   "Enable advanced options": "Включить дополнительные параметры",
-  "Enter the destination of the Lightning swap": "Введите пункт назначения обмена Lightning",
   "Escrow/Invoice Timer (HH:mm)": "Таймер эскроу/инвойса (ЧЧ:мм)",
   "Escrow/invoice step length": "Длина шага эскроу/инвойса",
   "Estimated Bond": "Расчетный залог",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -417,7 +417,6 @@
   "Description": "Beskrivning",
   "Edit order": "Redigera order",
   "Enable advanced options": "Aktivera avancerade alternativ",
-  "Enter the destination of the Lightning swap": "Ange destinationen för Lightning-bytet",
   "Escrow/Invoice Timer (HH:mm)": "Deposition/Faktura Timer (HH:mm)",
   "Escrow/invoice step length": "Deposition/faktura steg längd",
   "Estimated Bond": "Uppskattad deposition",

--- a/frontend/static/locales/sw.json
+++ b/frontend/static/locales/sw.json
@@ -417,7 +417,6 @@
   "Description": "Maelezo",
   "Edit order": "Hariri agizo",
   "Enable advanced options": "Washa chaguzi za juu",
-  "Enter the destination of the Lightning swap": "Ingiza marudio ya kubadilisha umeme",
   "Escrow/Invoice Timer (HH:mm)": "Muda wa Escrow/Ankara (HH:mm)",
   "Escrow/invoice step length": "Urefu wa hatua ya Escrow/Ankara",
   "Estimated Bond": "Dhamana Inayokadiriwa",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -417,7 +417,6 @@
   "Description": "คำอธิบาย",
   "Edit order": "แก้ไขคำสั่งซื้อ",
   "Enable advanced options": "เปิดใช้งานตัวเลือกขั้นสูง",
-  "Enter the destination of the Lightning swap": "ป้อนปลายทางของ Lightning swap",
   "Escrow/Invoice Timer (HH:mm)": "เครื่องจับเวลา Escrow/ใบแจ้งหนี้ (HH:mm)",
   "Escrow/invoice step length": "ความยาวขั้นตอน Escrow/ใบแจ้งหนี้",
   "Estimated Bond": "เงินประกันโดยประมาณ",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -417,7 +417,6 @@
   "Description": "描述",
   "Edit order": "编辑订单",
   "Enable advanced options": "启用高级选项",
-  "Enter the destination of the Lightning swap": "输入闪电交换的目的地",
   "Escrow/Invoice Timer (HH:mm)": "托管存款/发票倒计时 (HH:mm)",
   "Escrow/invoice step length": "托管/发票步长",
   "Estimated Bond": "预计保证金",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -417,7 +417,6 @@
   "Description": "描述",
   "Edit order": "編輯訂單",
   "Enable advanced options": "啟用高級選項",
-  "Enter the destination of the Lightning swap": "輸入閃電交換的目的地",
   "Escrow/Invoice Timer (HH:mm)": "託管存款/發票倒計時 (HH:mm)",
   "Escrow/invoice step length": "託管/發票步長",
   "Estimated Bond": "預計保證金",


### PR DESCRIPTION
## What does this PR do?
Fixes #2372

This PR introduces/refactors/...

* Store book filters (type, currency, mode) in localStorage and recover on reload
* Decouple Maker form filters from Order Book filters
* Changing filters in Create Order no longer affects Order Book

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.