### PR TITLE
fix bug low onchain balance results in infinite loading

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -746,10 +746,11 @@ class Logics:
             valid = cls.create_onchain_payment(
                 order, user, preliminary_amount=context["invoice_amount"]
             )
-            order.log(
-                f"Suggested mining fee is {order.payout_tx.suggested_mining_fee_rate} Sats/vbyte, the swap fee rate is {order.payout_tx.swap_fee_rate}%"
-            )
-            if not valid:
+            if valid:
+                order.log(
+                    f"Suggested mining fee is {order.payout_tx.suggested_mining_fee_rate} Sats/vbyte, the swap fee rate is {order.payout_tx.swap_fee_rate}%"
+                )
+            else:
                 context["swap_allowed"] = False
                 context["swap_failure_reason"] = (
                     "Not enough onchain liquidity available to offer a swap"


### PR DESCRIPTION
There is a bug that happens when the coordinator has low onchain balance that results in an infinite loading on the frontend when an order bigger than the coordinator onchain balance is taken.
This happens because `create_onchain_payment` returns `False` when `preliminary_amount > available_onchain` before adding `suggested_mining_fee_rate` to `onchain_payment`.
So `suggested_mining_fee_rate` was called without checking if `create_onchain_payment` returned `True`