### PR TITLE
fix broken log when slashed_robot

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -1806,7 +1806,7 @@ class Logics:
             slashed_robot = slashed_bond.sender.robot
             slashed_robot.earned_rewards += slashed_return
             slashed_robot.save(update_fields=["earned_rewards"])
-            slashed_robot_log = "Robot({slashed_robot.id},{slashed_robot.user.username}) was returned {slashed_return} Sats)"
+            slashed_robot_log = f"Robot({slashed_robot.id},{slashed_robot.user.username}) was returned {slashed_return} Sats"
 
         new_proceeds = int(slashed_satoshis * (1 - reward_fraction))
         order.proceeds += new_proceeds


### PR DESCRIPTION
`slashed_robot_log` was not expanded so it resulted in a literal `{slashed_robot.id}` ecc. and `_logs` in `api/admin.py` threw an exception here:
```python
with_hyperlinks = objects_to_hyperlinks(obj.logs)
try:
    html_logs = format_html(
        f'<table style="width: 100%">{with_hyperlinks}</table>'
    )
except Exception as e:
    html_logs = f"An error occurred while formatting the parsed logs as HTML. Exception {e}"
```

Also removed a trailing parenthesis.