### PR TITLE
Update grpcio and make gRPC generation portable

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,9 +8,9 @@ djangorestframework==3.16.1
 channels==4.2.2
 channels-redis==4.2.1
 celery==5.5.3
-grpcio==1.67.0
+grpcio==1.81.0
 googleapis-common-protos==1.70.0
-grpcio-tools==1.67.0
+grpcio-tools==1.81.0
 numpy==1.26.4
 Pillow==12.1.1
 python-decouple==3.8

--- a/scripts/generate_grpc.sh
+++ b/scripts/generate_grpc.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # generate LND grpc definitions
 cd api/lightning
@@ -14,29 +15,24 @@ curl --parallel -o lightning.proto https://raw.githubusercontent.com/lightningne
     -o primitives.proto https://raw.githubusercontent.com/ElementsProject/lightning/v24.08/cln-grpc/proto/primitives.proto \
     -o node.proto https://raw.githubusercontent.com/ElementsProject/lightning/v24.08/cln-grpc/proto/node.proto
 
-echo -n "Done\nBuilding api from GRPC specs..."
+printf "Done\nBuilding api from GRPC specs..."
 python3 -m grpc_tools.protoc --proto_path=googleapis:. --python_out=. --grpc_python_out=. lightning.proto invoices.proto router.proto signer.proto verrpc.proto
 python3 -m grpc_tools.protoc --proto_path=. --python_out=. --grpc_python_out=. node.proto hold.proto primitives.proto
 
 # patch generated files relative imports
-# LND
-sed -i 's/^import .*_pb2 as/from . \0/' router_pb2.py
-sed -i 's/^import .*_pb2 as/from . \0/' signer_pb2.py
-sed -i 's/^import .*_pb2 as/from . \0/' invoices_pb2.py
-sed -i 's/^import .*_pb2 as/from . \0/' verrpc_pb2.py
-sed -i 's/^import .*_pb2 as/from . \0/' router_pb2_grpc.py
-sed -i 's/^import .*_pb2 as/from . \0/' signer_pb2_grpc.py
-sed -i 's/^import .*_pb2 as/from . \0/' lightning_pb2_grpc.py
-sed -i 's/^import .*_pb2 as/from . \0/' invoices_pb2_grpc.py
-sed -i 's/^import .*_pb2 as/from . \0/' verrpc_pb2_grpc.py
+python3 <<'PY'
+from pathlib import Path
 
-# CLN
-sed -i 's/^import .*_pb2 as/from . \0/' hold_pb2.py
-sed -i 's/^import .*_pb2 as/from . \0/' hold_pb2_grpc.py
-sed -i 's/^import .*_pb2 as/from . \0/' node_pb2.py
-sed -i 's/^import .*_pb2 as/from . \0/' node_pb2_grpc.py
+for path in Path(".").glob("*_pb2*.py"):
+    lines = path.read_text().splitlines()
+    patched = [
+        f"from . {line}" if line.startswith("import ") and "_pb2 as " in line else line
+        for line in lines
+    ]
+    path.write_text("\n".join(patched) + "\n")
+PY
 
-echo -n "Done\nDeleting googleapi..."
+printf "Done\nDeleting googleapi..."
 rm -rf googleapis # delete googleapis
 echo "Done"
 


### PR DESCRIPTION
## What does this PR do?

Fixes #2171.

This updates the Python gRPC runtime/tooling to the current PyPI release and makes the generated-code import patching deterministic across environments.

Changes:
- update `grpcio` and `grpcio-tools` from 1.67.0 to 1.81.0
- make `scripts/generate_grpc.sh` fail fast with `set -eu`
- replace platform-specific `sed -i` import rewriting with a small Python rewrite step, so the generated `*_pb2*.py` files get package-relative imports consistently on Linux and BSD/macOS sed
- use `printf` for portable progress output

This is intentionally narrower than #2378: it only touches the dependency upgrade and gRPC generation path, without the unrelated API/lockfile changes that now conflict with `main`.

## Verification

Passed locally:
- `python3.12 -m venv .venv-grpc312`
- `.venv-grpc312/bin/python -m pip install grpcio==1.81.0 grpcio-tools==1.81.0 googleapis-common-protos==1.70.0`
- `PATH="$PWD/.venv-grpc312/bin:$PATH" sh scripts/generate_grpc.sh`
- imported generated LND/CLN modules: `hold_pb2`, `hold_pb2_grpc`, `lightning_pb2_grpc`, `node_pb2`, `node_pb2_grpc`
- `sh -n scripts/generate_grpc.sh`
- `.venv-grpc312/bin/python -m pip check`
- `git diff --check`

I also attempted the full CLN docker-compose test with `DOCKER_DEFAULT_PLATFORM=linux/amd64`, but the local run could not complete because Docker Hub image pulls repeatedly failed with TLS handshake timeouts.

## Bounty

This targets the `⚡Eligible for Sats ⚡` issue #2171. If this qualifies for the reward, payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`.
