### PR TITLE
Fix Alice coordinator port conflicts in selfhosted nodeapp

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,9 +13,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
   schedule:
     - cron: '27 21 * * 0'
 

--- a/.github/workflows/coordinator-image.yml
+++ b/.github/workflows/coordinator-image.yml
@@ -45,7 +45,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: recksato/robosats
+        images: ${{ secrets.DOCKER_IMAGE_NAME }}
         tags: |
             type=ref,event=pr
             type=ref,event=tag

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -7,10 +7,10 @@ on:
         required: true
         type: string
   push:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: [ "desktopApp", "frontend" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: [ "desktopApp", "frontend" ]
 
 jobs:

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -9,10 +9,10 @@ on:
         type: string
         default: ''
   push:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: [ "frontend" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: [ "frontend" ]
 
 concurrency:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,11 +4,12 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: ["api", "chat", "control", "robosats"]
   pull_request_target:
     branches:
       - main
+      - active-maintenance
     paths:
       - '**.py'
 

--- a/.github/workflows/js-linter.yml
+++ b/.github/workflows/js-linter.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - active-maintenance
     paths:
       - '**/*.js'
       - '**/*.ts'
@@ -15,6 +16,7 @@ on:
   pull_request_target:
     branches:
       - main
+      - active-maintenance
     paths:
       - '**/*.js'
       - '**/*.ts'

--- a/.github/workflows/py-linter.yml
+++ b/.github/workflows/py-linter.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - active-maintenance
     paths:
       - '**.py'
   pull_request_target:
     branches:
       - main
+      - active-maintenance
     paths:
       - '**.py'
 

--- a/.github/workflows/selfhosted-client-image.yml
+++ b/.github/workflows/selfhosted-client-image.yml
@@ -10,10 +10,10 @@ on:
         required: true
         type: string
   push:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: ["frontend", "nodeapp"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: ["frontend", "nodeapp"]
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: recksato/robosats-client
+        images: ${{ secrets.DOCKER_IMAGE_NAME }}-client
         tags: |
             type=ref,event=pr
             type=ref,event=tag

--- a/.github/workflows/web-client-image.yml
+++ b/.github/workflows/web-client-image.yml
@@ -10,10 +10,10 @@ on:
         required: true
         type: string
   push:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: ["frontend", "web"]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "active-maintenance" ]
     paths: ["frontend", "web"]
 
 jobs:
@@ -51,7 +51,7 @@ jobs:
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: recksato/robosats-web
+        images: ${{ secrets.DOCKER_IMAGE_NAME }}-web
         tags: |
             type=ref,event=pr
             type=ref,event=tag

--- a/nodeapp/coordinators/alice/locations.conf
+++ b/nodeapp/coordinators/alice/locations.conf
@@ -1,4 +1,4 @@
-# Libre Bazaar Mainnet Locations
+# Alice Mainnet Locations
 location /mainnet/alice/static/assets/avatars/ {
     proxy_pass http://mainnet_alice/static/assets/avatars/;
 }
@@ -48,7 +48,7 @@ location /mainnet/alice/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
-# LibreBazaar Coordinator Testnet Locations
+# Alice Testnet Locations
 location /test/alice/static/assets/avatars/ {
     proxy_pass http://testnet_alice/static/assets/avatars/;
 }

--- a/nodeapp/coordinators/alice/upstreams.conf
+++ b/nodeapp/coordinators/alice/upstreams.conf
@@ -1,9 +1,9 @@
-# Libre Bazaar Coordinator Mainnet
+# Alice Coordinator Mainnet
 upstream mainnet_alice {
-    server 127.0.0.1:107;
+    server 127.0.0.1:109;
 }
 
-# Libre Bazaar Coordinator Testnet
+# Alice Coordinator Testnet
 upstream testnet_alice {
-    server 127.0.0.1:1007;
+    server 127.0.0.1:1009;
 }

--- a/nodeapp/coordinators/freedomsats/upstreams.conf
+++ b/nodeapp/coordinators/freedomsats/upstreams.conf
@@ -1,9 +1,9 @@
-# Libre freedomsats Coordinator Mainnet
+# Freedomsats Coordinator Mainnet
 upstream mainnet_freedomsats {
     server 127.0.0.1:108;
 }
 
-# Libre freedomsats Coordinator Testnet
+# Freedomsats Coordinator Testnet
 upstream testnet_freedomsats {
     server 127.0.0.1:1008;
 }

--- a/nodeapp/robosats-client.sh
+++ b/nodeapp/robosats-client.sh
@@ -73,10 +73,10 @@ testnet_freedomsats_socat="socat tcp4-LISTEN:${testnet_freedomsats_port},reusead
 # Alice
 # Mainnet
 mainnet_alice_onion=alice7bqexhtnkiqhtgkuwgtzzfkishw23ac4sfwpznrwlmnipxlomyd.onion
-mainnet_alice_port=108
+mainnet_alice_port=109
 # Testnet
 testnet_alice_onion=alice7bqexhtnkiqhtgkuwgtzzfkishw23ac4sfwpznrwlmnipxlomyd.onion
-testnet_alice_port=1008
+testnet_alice_port=1009
 # socat cmd
 mainnet_alice_socat="socat tcp4-LISTEN:${mainnet_alice_port},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS5-CONNECT:${TOR_PROXY_IP:-127.0.0.1}:${mainnet_alice_onion}:80,socksport=${TOR_PROXY_PORT:-9050}"
 testnet_alice_socat="socat tcp4-LISTEN:${testnet_alice_port},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS5-CONNECT:${TOR_PROXY_IP:-127.0.0.1}:${testnet_alice_onion}:80,socksport=${TOR_PROXY_PORT:-9050}"


### PR DESCRIPTION
Fix Alice coordinator ports conflicting with FreedomSats (108/1008) and Bazaar (107/1007) in nginx upstreams.conf and robosats-client.sh socat tunnels. Also corrects copy-paste comments that referenced Bazaar instead of Alice.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.