### PR TITLE
Revert "fix: resolve order page loading race condn"

### DIFF
--- a/frontend/src/basic/OrderPage/index.tsx
+++ b/frontend/src/basic/OrderPage/index.tsx
@@ -31,7 +31,6 @@ const OrderPage = (): React.JSX.Element => {
     acknowledgedWarning,
     setAcknowledgedWarning,
     navbarHeight,
-    slotUpdatedAt,
   } = useContext<UseAppStoreType>(AppContext);
   const { federation } = useContext<UseFederationStoreType>(FederationContext);
   const { garage } = useContext<UseGarageStoreType>(GarageContext);
@@ -69,7 +68,7 @@ const OrderPage = (): React.JSX.Element => {
     return () => {
       setCurrentOrder(null);
     };
-  }, [params.orderId, openNoRobot, garage.currentSlot, slotUpdatedAt]);
+  }, [params.orderId, openNoRobot, garage.currentSlot]);
 
   useEffect(() => {
     if (!currentOrder) return;


### PR DESCRIPTION
Commit 93419f5f added slotUpdatedAt to the OrderPage useEffect dependency array. This created an infinite loop: the effect fetched the order, which called slot.updateSlotFromOrder(), which triggered onSlotUpdate() -> setSlotUpdatedAt(), which re-triggered the effect. Each cycle also fired the TradeBox WebLN effect, causing repeated getWebln() calls and an infinite popup loop when the user rejected the WebLN prompt.

Reverting restores the original dependency array [params.orderId, openNoRobot, garage.currentSlot], breaking the self-referential fetch loop while preserving all existing functionality.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.