### PR TITLE
Fix self-hosted image uploads

### DIFF
--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedApiChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedApiChat/index.tsx
@@ -38,6 +38,7 @@ interface Props {
   setPeerPubKey: (peerPubKey: string) => void;
   setError: Dispatch<SetStateAction<string>>;
   setLastIndex: Dispatch<SetStateAction<number>>;
+  coordinatorUrl: string;
 }
 
 const audioPath =
@@ -62,6 +63,7 @@ const EncryptedApiChat: React.FC<Props> = ({
   onSendFile,
   setError,
   setLastIndex,
+  coordinatorUrl,
 }: Props): React.JSX.Element => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -288,6 +290,7 @@ const EncryptedApiChat: React.FC<Props> = ({
                   makerHashId={makerHashId}
                   imageUrls={imageUrls}
                   setImageUrls={setImageUrls}
+                  coordinatorUrl={coordinatorUrl}
                 />
               </li>
             );

--- a/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/EncryptedSocketChat/index.tsx
@@ -49,6 +49,7 @@ interface Props {
   onSendFile: (file: File) => Promise<void>;
   peerPubKey?: string;
   setPeerPubKey: (peerPubKey: string) => void;
+  coordinatorUrl: string;
 }
 
 const EncryptedSocketChat: React.FC<Props> = ({
@@ -64,6 +65,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
   onSendFile,
   peerPubKey,
   setPeerPubKey,
+  coordinatorUrl,
 }: Props): React.JSX.Element => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -358,6 +360,7 @@ const EncryptedSocketChat: React.FC<Props> = ({
                   makerHashId={makerHashId}
                   imageUrls={imageUrls}
                   setImageUrls={setImageUrls}
+                  coordinatorUrl={coordinatorUrl}
                 />
               </li>
             );

--- a/frontend/src/components/TradeBox/EncryptedChat/MessageCard/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/MessageCard/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   userConnected?: boolean;
   imageUrls: Record<number, string>;
   setImageUrls: (imageUrls: Record<number, string>) => Record<number, string>;
+  coordinatorUrl: string;
 }
 
 const MessageCard: React.FC<Props> = ({
@@ -33,6 +34,7 @@ const MessageCard: React.FC<Props> = ({
   makerHashId,
   imageUrls,
   setImageUrls,
+  coordinatorUrl,
 }) => {
   const [imageError, setImageError] = useState<string | null>(null);
   const [openLightbox, setOpenLightbox] = useState<boolean>(false);
@@ -62,7 +64,8 @@ const MessageCard: React.FC<Props> = ({
         return;
       }
 
-      const ciphertext = await downloadFromBlossom(fileData.url);
+      const downloadUrl = `${coordinatorUrl}/blossom/${fileData.sha256}`;
+      const ciphertext = await downloadFromBlossom(downloadUrl);
       const isValid = await verifyBlobHash(ciphertext, fileData.sha256);
 
       if (!isValid) {

--- a/frontend/src/components/TradeBox/EncryptedChat/MessageCard/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/MessageCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { IconButton, Tooltip, Card, CardHeader, useTheme } from '@mui/material';
 import RobotAvatar from '../../../RobotAvatar';
 import { systemClient } from '../../../../services/System';
@@ -38,6 +38,7 @@ const MessageCard: React.FC<Props> = ({
 }) => {
   const [imageError, setImageError] = useState<string | null>(null);
   const [openLightbox, setOpenLightbox] = useState<boolean>(false);
+  const blobUrlRef = useRef<string | null>(null);
   const { t } = useTranslation();
   const theme = useTheme();
 
@@ -46,13 +47,12 @@ const MessageCard: React.FC<Props> = ({
   const cardColor = isTaker ? takerCardColor : makerCardColor;
 
   useEffect(() => {
-    // Cleanup blob URL on unmount
     return () => {
-      if (imageUrls[message.index]) {
-        URL.revokeObjectURL(imageUrls[message.index]);
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
       }
     };
-  }, [imageUrls[message.index]]);
+  }, []);
 
   const handleImageLoad = async () => {
     if (imageUrls[message.index] || !message.fileMetadata || imageError) return;
@@ -77,10 +77,12 @@ const MessageCard: React.FC<Props> = ({
       const blob = new Blob([plaintext], { type: fileData.mimeType });
       const url = URL.createObjectURL(blob);
 
-      setImageUrls((urls) => {
-        urls[message.index] = url;
-        return urls;
-      });
+      if (blobUrlRef.current) {
+        URL.revokeObjectURL(blobUrlRef.current);
+      }
+      blobUrlRef.current = url;
+
+      setImageUrls((prev) => ({ ...prev, [message.index]: url }));
     } catch (error) {
       console.error('Failed to load image:', error);
       setImageError(t('Failed to decrypt image'));

--- a/frontend/src/components/TradeBox/EncryptedChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/index.tsx
@@ -148,8 +148,11 @@ const EncryptedChat: React.FC<Props> = ({
       const fileUint8 = new Uint8Array(fileBuffer);
       const originalSha256 = await computeSha256(fileUint8);
 
+      const network = settings.network as 'mainnet' | 'testnet';
+      const canonicalUrl = coordinator[network]?.onion || coordinator.url;
+
       const { ciphertext, nonce } = await encryptFile(fileBuffer, key);
-      const { url, sha256 } = await uploadToBlossom(ciphertext, coordinator.url, slot.nostrSecKey);
+      const { url, sha256 } = await uploadToBlossom(ciphertext, coordinator.url, slot.nostrSecKey, canonicalUrl);
 
       const fileEvent = createFileMessage({
         url,
@@ -210,6 +213,8 @@ const EncryptedChat: React.FC<Props> = ({
   //   );
   // }
 
+  const coordinatorUrl = federation.getCoordinator(order.shortAlias).url;
+
   return settings.connection === 'api' ? (
     <EncryptedApiChat
       messages={messages}
@@ -228,6 +233,7 @@ const EncryptedChat: React.FC<Props> = ({
       setError={setError}
       lastIndex={lastIndex}
       setLastIndex={setLastIndex}
+      coordinatorUrl={coordinatorUrl}
     />
   ) : (
     <EncryptedSocketChat
@@ -243,6 +249,7 @@ const EncryptedChat: React.FC<Props> = ({
       peerPubKey={peerPubKey}
       setPeerPubKey={setPeerPubKey}
       status={order.status}
+      coordinatorUrl={coordinatorUrl}
     />
   );
 };

--- a/frontend/src/utils/blossom.ts
+++ b/frontend/src/utils/blossom.ts
@@ -1,9 +1,9 @@
+import { sha256 } from '@noble/hashes/sha256';
 import { finalizeEvent, type EventTemplate } from 'nostr-tools';
 import { apiClient } from '../services/api';
 
 export async function computeSha256(data: Uint8Array): Promise<string> {
-  const hashBuffer = await crypto.subtle.digest('SHA-256', data.slice().buffer);
-  return Array.from(new Uint8Array(hashBuffer))
+  return Array.from(sha256(data))
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
 }

--- a/frontend/src/utils/blossom.ts
+++ b/frontend/src/utils/blossom.ts
@@ -35,6 +35,7 @@ export async function uploadToBlossom(
   ciphertext: Uint8Array,
   coordinatorUrl: string,
   nostrSecKey: Uint8Array,
+  canonicalUrl?: string,
 ): Promise<BlossomUploadResult> {
   const sha256 = await computeSha256(ciphertext);
   const authToken = createAuthEvent(sha256, nostrSecKey);
@@ -42,7 +43,7 @@ export async function uploadToBlossom(
   await apiClient.sendBinary(coordinatorUrl, '/blossom/upload', ciphertext, `Nostr ${authToken}`);
 
   return {
-    url: `${coordinatorUrl}/blossom/${sha256}`,
+    url: `${(canonicalUrl ?? coordinatorUrl)}/blossom/${sha256}`,
     sha256,
   };
 }

--- a/nodeapp/coordinators/alice/locations.conf
+++ b/nodeapp/coordinators/alice/locations.conf
@@ -48,7 +48,15 @@ location /mainnet/alice/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
-# LibreBazaar Coordinator Testnet Locations
+location /mainnet/alice/blossom/ {
+    proxy_pass http://mainnet_alice/blossom/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+# Alice Testnet Locations
 location /test/alice/static/assets/avatars/ {
     proxy_pass http://testnet_alice/static/assets/avatars/;
 }
@@ -63,6 +71,14 @@ location /testnet/alice/api/ {
 
 location /testnet/alice/ws/ {
     proxy_pass http://testnet_alice/ws/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+location /testnet/alice/blossom/ {
+    proxy_pass http://testnet_alice/blossom/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/nodeapp/coordinators/bazaar/locations.conf
+++ b/nodeapp/coordinators/bazaar/locations.conf
@@ -48,6 +48,14 @@ location /mainnet/bazaar/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
+location /mainnet/bazaar/blossom/ {
+    proxy_pass http://mainnet_bazaar/blossom/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # LibreBazaar Coordinator Testnet Locations
 location /test/bazaar/static/assets/avatars/ {
     proxy_pass http://testnet_bazaar/static/assets/avatars/;
@@ -63,6 +71,14 @@ location /testnet/bazaar/api/ {
 
 location /testnet/bazaar/ws/ {
     proxy_pass http://testnet_bazaar/ws/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+location /testnet/bazaar/blossom/ {
+    proxy_pass http://testnet_bazaar/blossom/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/nodeapp/coordinators/freedomsats/locations.conf
+++ b/nodeapp/coordinators/freedomsats/locations.conf
@@ -48,6 +48,14 @@ location /mainnet/freedomsats/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
+location /mainnet/freedomsats/blossom/ {
+    proxy_pass http://mainnet_freedomsats/blossom/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Freedomsats Coordinator Testnet Locations
 location /test/freedomsats/static/assets/avatars/ {
     proxy_pass http://testnet_freedomsats/static/assets/avatars/;
@@ -63,6 +71,14 @@ location /testnet/freedomsats/api/ {
 
 location /testnet/freedomsats/ws/ {
     proxy_pass http://testnet_freedomsats/ws/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+location /testnet/freedomsats/blossom/ {
+    proxy_pass http://testnet_freedomsats/blossom/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/nodeapp/coordinators/lake/locations.conf
+++ b/nodeapp/coordinators/lake/locations.conf
@@ -48,6 +48,14 @@ location /mainnet/lake/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
+location /mainnet/lake/blossom/ {
+    proxy_pass http://mainnet_lake/blossom/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # TheBigLake Coordinator Testnet Locations
 location /test/lake/static/assets/avatars/ {
     proxy_pass http://testnet_lake/static/assets/avatars/;
@@ -63,6 +71,14 @@ location /testnet/lake/api/ {
 
 location /testnet/lake/ws/ {
     proxy_pass http://testnet_lake/ws/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+location /testnet/lake/blossom/ {
+    proxy_pass http://testnet_lake/blossom/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/nodeapp/coordinators/moon/locations.conf
+++ b/nodeapp/coordinators/moon/locations.conf
@@ -48,6 +48,14 @@ location /mainnet/moon/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
+location /mainnet/moon/blossom/ {
+    proxy_pass http://mainnet_moon/blossom/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Over the Moon Coordinator Testnet Locations
 location /test/moon/static/assets/avatars/ {
     proxy_pass http://testnet_moon/static/assets/avatars/;
@@ -63,6 +71,14 @@ location /testnet/moon/api/ {
 
 location /testnet/moon/ws/ {
     proxy_pass http://testnet_moon/ws/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+location /testnet/moon/blossom/ {
+    proxy_pass http://testnet_moon/blossom/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/nodeapp/coordinators/temple/locations.conf
+++ b/nodeapp/coordinators/temple/locations.conf
@@ -48,6 +48,14 @@ location /mainnet/temple/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
+location /mainnet/temple/blossom/ {
+    proxy_pass http://mainnet_temple/blossom/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
 # Temple of Sats Coordinator Testnet Locations
 location /test/temple/static/assets/avatars/ {
     proxy_pass http://testnet_temple/static/assets/avatars/;
@@ -63,6 +71,14 @@ location /testnet/temple/api/ {
 
 location /testnet/temple/ws/ {
     proxy_pass http://testnet_temple/ws/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Host $host;
+}
+
+location /testnet/temple/blossom/ {
+    proxy_pass http://testnet_temple/blossom/;
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";

--- a/nodeapp/nginx.conf
+++ b/nodeapp/nginx.conf
@@ -26,6 +26,8 @@ http {
     sendfile        on;
     keepalive_timeout  65;
 
+    client_max_body_size 11M;
+
     # Every robosat coordinators socat tor bridge is an upstream.
     # Coordinators in the federation:
     # Temple of Sats


### PR DESCRIPTION
## What does this PR do?
- Remove the browser secure-context dependency for image hashing on HTTP self-hosted setups.
- Add Blossom proxy routes and increase upload size limits in nginx.
- Store canonical Onion URLs in Blossom metadata to support cross-network downloads.
- Prevent state mutation so image blobs trigger re-renders and display correctly.

This is a copy of PR [#9](https://github.com/Robosats-Federation/robosats/pull/9#issue-4804050852)

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.