### PR TITLE
Fix: Remove early return in follow_invoices

### DIFF
--- a/api/management/commands/follow_invoices.py
+++ b/api/management/commands/follow_invoices.py
@@ -178,7 +178,7 @@ class Command(BaseCommand):
             # Checks that this onchain payment is part of an order with a settled escrow
             if not hasattr(lnpayment, "order_paid_LN"):
                 self.stderr.write(f"Ln payment {str(lnpayment)} has no parent order!")
-                return
+                continue
             order = lnpayment.order_paid_LN
             if (
                 order.trade_escrow.status == LNPayment.Status.SETLED
@@ -198,7 +198,7 @@ class Command(BaseCommand):
                 self.stderr.write(
                     f"Onchain payment {str(onchainpayment)} has no parent order!"
                 )
-                return
+                continue
             order = onchainpayment.order_paid_TX
             if (
                 order.trade_escrow.status == LNPayment.Status.SETLED


### PR DESCRIPTION
## What does this PR do?
The follow_invoices command used return when encountering orphan payments (with no parent order), which prematurely aborted the entire processing loop. The fix replaces both return statements with continue, so the command simply skips the problematic record and proceeds with remaining payments, making execution resilient to inconsistent data.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.