### PR TITLE
Fix Alice coordinator port conflicts in selfhosted nodeapp

### DIFF
--- a/nodeapp/coordinators/alice/locations.conf
+++ b/nodeapp/coordinators/alice/locations.conf
@@ -1,4 +1,4 @@
-# Libre Bazaar Mainnet Locations
+# Alice Mainnet Locations
 location /mainnet/alice/static/assets/avatars/ {
     proxy_pass http://mainnet_alice/static/assets/avatars/;
 }
@@ -48,7 +48,7 @@ location /mainnet/alice/relay/ {
     add_header Access-Control-Allow-Origin *;
 }
 
-# LibreBazaar Coordinator Testnet Locations
+# Alice Testnet Locations
 location /test/alice/static/assets/avatars/ {
     proxy_pass http://testnet_alice/static/assets/avatars/;
 }

--- a/nodeapp/coordinators/alice/upstreams.conf
+++ b/nodeapp/coordinators/alice/upstreams.conf
@@ -1,9 +1,9 @@
-# Libre Bazaar Coordinator Mainnet
+# Alice Coordinator Mainnet
 upstream mainnet_alice {
-    server 127.0.0.1:107;
+    server 127.0.0.1:109;
 }
 
-# Libre Bazaar Coordinator Testnet
+# Alice Coordinator Testnet
 upstream testnet_alice {
-    server 127.0.0.1:1007;
+    server 127.0.0.1:1009;
 }

--- a/nodeapp/coordinators/freedomsats/upstreams.conf
+++ b/nodeapp/coordinators/freedomsats/upstreams.conf
@@ -1,9 +1,9 @@
-# Libre freedomsats Coordinator Mainnet
+# Freedomsats Coordinator Mainnet
 upstream mainnet_freedomsats {
     server 127.0.0.1:108;
 }
 
-# Libre freedomsats Coordinator Testnet
+# Freedomsats Coordinator Testnet
 upstream testnet_freedomsats {
     server 127.0.0.1:1008;
 }

--- a/nodeapp/robosats-client.sh
+++ b/nodeapp/robosats-client.sh
@@ -73,10 +73,10 @@ testnet_freedomsats_socat="socat tcp4-LISTEN:${testnet_freedomsats_port},reusead
 # Alice
 # Mainnet
 mainnet_alice_onion=alice7bqexhtnkiqhtgkuwgtzzfkishw23ac4sfwpznrwlmnipxlomyd.onion
-mainnet_alice_port=108
+mainnet_alice_port=109
 # Testnet
 testnet_alice_onion=alice7bqexhtnkiqhtgkuwgtzzfkishw23ac4sfwpznrwlmnipxlomyd.onion
-testnet_alice_port=1008
+testnet_alice_port=1009
 # socat cmd
 mainnet_alice_socat="socat tcp4-LISTEN:${mainnet_alice_port},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS5-CONNECT:${TOR_PROXY_IP:-127.0.0.1}:${mainnet_alice_onion}:80,socksport=${TOR_PROXY_PORT:-9050}"
 testnet_alice_socat="socat tcp4-LISTEN:${testnet_alice_port},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS5-CONNECT:${TOR_PROXY_IP:-127.0.0.1}:${testnet_alice_onion}:80,socksport=${TOR_PROXY_PORT:-9050}"


### PR DESCRIPTION
## What does this PR do?
Fix Alice coordinator ports conflicting with FreedomSats (108/1008) and Bazaar (107/1007) in nginx upstreams.conf and robosats-client.sh socat tunnels. Also corrects copy-paste comments that referenced Bazaar instead of Alice.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.