### PR TITLE
feat: validate PGP key creation timestamp

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -59,6 +59,7 @@ ERRORS = {
     1051: "More than 5000 market ticks have been found. Please, narrow the date range",
     1052: "Robot has no finished order",
     1053: "Wrong hex pubkey",
+    1056: "Your PGP public key was created too recently ({key_creation_date}). Keys must be at least 12 hours old. Please check your system clock and generate a new key.",
     # 2000 - Bad statement
     2000: "The statement and chat logs are longer than 50,000 characters",
     2001: "The statement is too short. Make sure to be thorough.",

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,8 +1,13 @@
+import shutil
+import subprocess
+import tempfile
+from datetime import timedelta
 from unittest.mock import Mock, mock_open, patch
 
 import numpy as np
 from decouple import config
 from django.test import TestCase
+from django.utils import timezone
 
 from api.utils import (
     base91_to_hex,
@@ -20,6 +25,51 @@ from api.utils import (
     verify_signed_message,
     weighted_median,
 )
+
+
+def _gen_test_key(homedir: str, creation_date: str | None = None):
+    lines = [
+        "Key-Type: RSA",
+        "Key-Length: 4096",
+        "Subkey-Type: RSA",
+        "Subkey-Length: 4096",
+        "Name-Real: Test Robot",
+        "Name-Email: test@test.com",
+        "Expire-Date: 0",
+    ]
+    if creation_date is not None:
+        lines.append(f"Creation-Date: {creation_date}")
+    lines.extend(["%no-protection", "%commit"])
+    batch = "\n".join(lines) + "\n"
+    subprocess.run(
+        ["gpg", "--batch", "--homedir", homedir, "--gen-key"],
+        input=batch,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    result = subprocess.run(
+        ["gpg", "--homedir", homedir, "--list-keys", "--with-colons"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    fingerprint = [
+        line for line in result.stdout.splitlines() if line.startswith("fpr:")
+    ][0].split(":")[9]
+    pub = subprocess.run(
+        ["gpg", "--homedir", homedir, "--armor", "--export", fingerprint],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    priv = subprocess.run(
+        ["gpg", "--homedir", homedir, "--armor", "--export-secret-keys", fingerprint],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return pub, priv
 
 
 class TestUtils(TestCase):
@@ -157,6 +207,37 @@ class TestUtils(TestCase):
         self.assertIsNotNone(error)
         self.assertIsNone(returned_pub_key)
         self.assertIsNone(returned_enc_priv_key)
+
+    def test_pgp_key_13h_ago_passes(self):
+        ts = (timezone.now() - timedelta(hours=13)).strftime("%Y%m%dT%H%M%S")
+        tmp = tempfile.mkdtemp()
+        try:
+            pub_key, enc_priv_key = _gen_test_key(tmp, creation_date=ts)
+            is_valid, error, _, _ = validate_pgp_keys(pub_key, enc_priv_key)
+            self.assertTrue(is_valid)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_pgp_key_11h_ago_fails(self):
+        ts = (timezone.now() - timedelta(hours=11)).strftime("%Y%m%dT%H%M%S")
+        tmp = tempfile.mkdtemp()
+        try:
+            pub_key, enc_priv_key = _gen_test_key(tmp, creation_date=ts)
+            is_valid, error, _, _ = validate_pgp_keys(pub_key, enc_priv_key)
+            self.assertFalse(is_valid)
+            self.assertEqual(error["error_code"], 1056)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    def test_pgp_key_now_fails(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            pub_key, enc_priv_key = _gen_test_key(tmp)
+            is_valid, error, _, _ = validate_pgp_keys(pub_key, enc_priv_key)
+            self.assertFalse(is_valid)
+            self.assertEqual(error["error_code"], 1056)
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
 
     def test_verify_signed_message(self):
         # Call the verify_signed_message function with a mock public key and a mock signed message

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,6 +1,8 @@
 import json
 import logging
 import re
+from datetime import datetime, timedelta
+from datetime import timezone as datetime_timezone
 
 import gnupg
 import numpy as np
@@ -8,6 +10,7 @@ import requests
 import ring
 from base91 import decode, encode
 from decouple import config
+from django.utils import timezone
 
 from api.errors import new_error
 
@@ -387,6 +390,21 @@ def validate_pgp_keys(pub_key, enc_priv_key):
                 None,
                 None,
             )
+    # Check key creation timestamp
+    if import_pub_result.fingerprints:
+        keys = gpg.list_keys(keys=import_pub_result.fingerprints[0])
+        if keys:
+            key_creation = datetime.fromtimestamp(
+                int(keys[0]["date"]), tz=datetime_timezone.utc
+            )
+            if key_creation > timezone.now() - timedelta(hours=12):
+                return (
+                    False,
+                    new_error(1056, {"key_creation_date": key_creation.isoformat()}),
+                    None,
+                    None,
+                )
+
     # Exports the public key again for uniform formatting.
     pub_key = gpg.export_keys(import_pub_result.fingerprints[0])
 
@@ -499,7 +517,9 @@ def objects_to_hyperlinks(logs: str) -> str:
         for obj in objects:
             logs = re.sub(
                 rf"{obj}\(([0-9a-fA-F\-A-F]+),\s*([^)]+)\)",
-                lambda m: f'<b><a href="/coordinator/api/{obj.lower()}/{m.group(1)}">{m.group(2)}</a></b>',
+                lambda m: (
+                    f'<b><a href="/coordinator/api/{obj.lower()}/{m.group(1)}">{m.group(2)}</a></b>'
+                ),
                 logs,
                 flags=re.DOTALL,
             )


### PR DESCRIPTION
## What does this PR do?
Add timestamp validation in validate_pgp_keys() to reject PGP keys created less than 12 hours ago. This prevents robots with future-dated keys (caused by system clock mismatch) from being registered, which would otherwise break frontend message encryption.

The frontend already sets key date to yesterday (1 day offset), so legitimate keys (~24h old) pass the 12-hour threshold.

Tests generate real RSA keys with gpg --batch --gen-key using Creation-Date in YYYYMMDDThhmmss format to cover three scenarios: 13h old (passes), 11h old (error 1056), and freshly created (error 1056).

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.