### PR TITLE
fix(security): F4 — is_valid_onion_url enforces http scheme only

### DIFF
--- a/api/models/robot.py
+++ b/api/models/robot.py
@@ -93,7 +93,13 @@ class Robot(models.Model):
 
     @staticmethod
     def is_valid_onion_url(url):
-        """Validates that the URL is a .onion address (Tor only)"""
+        """Validates that the URL is a valid http .onion address (Tor only).
+
+        Enforces:
+        - scheme must be 'http' (the only scheme Tor hidden services use for callbacks)
+        - hostname must end with '.onion' (no double-dots or tricks)
+        - hostname must not be empty
+        """
         if not url:
             return False
         try:
@@ -101,7 +107,12 @@ class Robot(models.Model):
 
             parsed = urlparse(url)
             hostname = parsed.hostname or ""
-            return hostname.endswith(".onion")
+            return (
+                parsed.scheme == "http"
+                and hostname.endswith(".onion")
+                and not hostname.endswith("..onion")
+                and len(hostname) > len(".onion")
+            )
         except Exception:
             return False
 


### PR DESCRIPTION
is_valid_onion_url only checked hostname.endswith('.onion') allowing any scheme (file://, ftp://, ssh://) and empty/double-dot hostnames.

Fix: require parsed.scheme == 'http', non-empty hostname > '.onion', and reject '..onion' double-dot tricks.

Regresion tests added in https://github.com/RoboSats/robosats/pull/2543

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.