### PR TITLE
fix(security): F3 — handle IntegrityError on robot nickname collision

### DIFF
--- a/api/errors.py
+++ b/api/errors.py
@@ -89,6 +89,7 @@ ERRORS = {
     7001: "On the first request to a RoboSats coordinator, you must provide as well a valid public and encrypted private PGP keys and a nostr pubkey",
     7002: "Invalid keys: {bad_keys_context}",
     7003: "Authentication credentials were not provided.",
+    7004: "Robot nickname already taken. Please try a different token.",
 }
 
 

--- a/robosats/middleware.py
+++ b/robosats/middleware.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from channels.db import database_sync_to_async
 from channels.middleware import BaseMiddleware
 from django.contrib.auth.models import AnonymousUser, User, update_last_login
+from django.db import IntegrityError
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
 from django.http import JsonResponse
@@ -132,7 +133,14 @@ class RobotTokenSHA256AuthenticationMiddleWare:
             # Generate nickname deterministically
             nickname = NickGen.short_from_SHA256(hash, max_length=18)[0]
 
-            user = User.objects.create_user(username=nickname, password=None)
+            try:
+                user = User.objects.create_user(username=nickname, password=None)
+            except IntegrityError:
+                # Nickname collision: this hash already has a user (race condition or
+                # NickGen pool exhaustion). Return a conflict error instead of a 500.
+                return JsonResponse(
+                    new_error(7004), status=status.HTTP_409_CONFLICT
+                )
 
             # Store hash_id
             user.robot.hash_id = hash


### PR DESCRIPTION
User.objects.create_user raised an unhandled IntegrityError (500) when a nickname was already taken due to NickGenerator hash collision or race.

Fix: wrap create_user in try/except IntegrityError, return HTTP 409 with error code 7004 instead of crashing the request.

Regresion tests added in https://github.com/RoboSats/robosats/pull/2543

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.