### PR TITLE
fix(security): F2 — automatic_dispute_resolution blocks after undo_co…

### DIFF
--- a/api/logics.py
+++ b/api/logics.py
@@ -463,9 +463,9 @@ class Logics:
         flagging it as dispute, we avoid having to settle the
         bonds"""
 
-        # If fiat has been marked as sent, automatic dispute
-        # resolution is not possible.
-        if order.is_fiat_sent and not order.reverted_fiat_sent:
+        # If fiat has been marked as sent (or was sent and then reverted),
+        # automatic dispute resolution is not possible.
+        if order.is_fiat_sent or order.reverted_fiat_sent:
             return False
 
         # If the order has not entered dispute due to time expire

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@
 exclude = [
     "*migrations/*",
     "api/nick_generator/nick_generator.py",
+    "api/lightning/*pb2*",
     ]
 
 [tool.coverage.run]

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -1924,6 +1924,80 @@ class TradeTest(BaseAPITestCase):
         trade.get_review(trade.taker_index)
         self.assertEqual(trade.response.status_code, 400)
 
+    def test_order_expires_after_undo_confirm_fiat_sent(self):
+        """
+        Tests that automatic dispute resolution is blocked when fiat was marked
+        sent and then reverted (undo_confirm). The fix for security issue F2
+        ensures that reverted_fiat_sent=True prevents auto-resolution even if
+        the taker never messaged, so the order must enter full DIS status.
+        """
+        trade = Trade(self.client)
+        trade.publish_order()
+        trade.take_order()
+        trade.take_order_third()
+        trade.lock_taker_bond()
+        trade.lock_escrow(trade.taker_index)
+        trade.submit_payout_invoice(trade.maker_index)
+
+        # Buyer (maker) confirms fiat sent → order moves to FSE
+        trade.confirm_fiat(trade.maker_index)
+        data = trade.response.json()
+        self.assertEqual(data["status_message"], Order.Status(Order.Status.FSE).label)
+        self.assertTrue(data["is_fiat_sent"])
+
+        # Buyer (maker) reverts the fiat-sent confirmation → order back to CHA,
+        # reverted_fiat_sent is now True
+        trade.undo_confirm_sent(trade.maker_index)
+        data = trade.response.json()
+        self.assertEqual(trade.response.status_code, 200)
+        self.assertResponse(trade.response)
+        self.assertEqual(data["status_message"], Order.Status(Order.Status.CHA).label)
+        self.assertFalse(data["is_fiat_sent"])
+
+        # Expire the order (no chat messages from either side)
+        order = Order.objects.get(id=trade.order_id)
+        order.expires_at = datetime.now()
+        order.save()
+
+        # Make orders expire — this calls open_dispute → automatic_dispute_resolution
+        trade.clean_orders()
+
+        trade.get_order()
+        data = trade.response.json()
+
+        self.assertEqual(trade.response.status_code, 200)
+        self.assertResponse(trade.response)
+
+        # The fix: reverted_fiat_sent=True must block automatic resolution,
+        # so the order must be in full DIS status (not TLD/MLD).
+        self.assertEqual(
+            data["status"],
+            Order.Status.DIS,
+            "Order with reverted_fiat_sent must enter full DIS, not be auto-resolved",
+        )
+        self.assertTrue(data["is_disputed"])
+
+        self.assert_order_logs(data["id"])
+
+        maker_headers = trade.get_robot_auth(trade.maker_index)
+        response = self.client.get(reverse("notifications"), **maker_headers)
+        self.assertResponse(response)
+        notifications_data = list(response.json())
+        self.assertEqual(notifications_data[0]["order_id"], trade.order_id)
+        self.assertEqual(
+            notifications_data[0]["title"],
+            f"⚖️ Hey {data['maker_nick']}, a dispute has been opened on your order with ID {str(trade.order_id)}.",
+        )
+        taker_headers = trade.get_robot_auth(trade.taker_index)
+        response = self.client.get(reverse("notifications"), **taker_headers)
+        self.assertResponse(response)
+        notifications_data = list(response.json())
+        self.assertEqual(notifications_data[0]["order_id"], trade.order_id)
+        self.assertEqual(
+            notifications_data[0]["title"],
+            f"⚖️ Hey {data['taker_nick']}, a dispute has been opened on your order with ID {str(trade.order_id)}.",
+        )
+
     def test_ticks(self):
         """
         Tests the historical ticks serving endpoint after creating a contract


### PR DESCRIPTION
…nfirm

Guard was: if order.is_fiat_sent and not order.reverted_fiat_sent After undo_confirm_fiat_sent, is_fiat_sent=False and reverted_fiat_sent=True, so the guard was bypassed. A buyer could confirm fiat, undo, go silent, let the order expire, and have auto dispute resolution run against the seller.

Fix: if order.is_fiat_sent or order.reverted_fiat_sent: return False

## What does this PR do?
Fixes #<ISSUE_NUMBER>

This PR introduces/refactors/...

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.