### PR TITLE
fix: replace broken curl HEALTHCHECK with wget in Docker images

### DIFF
--- a/nodeapp/AGENTS.md
+++ b/nodeapp/AGENTS.md
@@ -19,7 +19,7 @@ Host :12596  (published on the tor service — see Traps)
         ├── /pro                  → SPA (pro.html)
         ├── /static/              → filesystem alias /usr/src/robosats/static/ (autoindex on)
         ├── /favicon.ico          → filesystem alias /usr/src/robosats/static/assets/images/favicon-32x32.png
-        ├── /selfhosted           → 200 OK (container healthcheck probe — curl absent, see Traps)
+        ├── /selfhosted           → 200 OK (container healthcheck probe)
         └── /mainnet/{alias}/...
         └── /testnet/{alias}/...  → socat upstreams (127.0.0.1:{port})
               └── socat tcp4-LISTEN:{port} … SOCKS5-CONNECT:{Tor}:{onion}:80
@@ -33,7 +33,7 @@ No clearnet path exists; no I2P fallback is implemented.
 |---|---|
 | `robosats-client.sh` | Starts 12 socat bridges (2 per coordinator: mainnet + testnet) then `nginx` in foreground |
 | `nginx.conf` | Nginx config; `daemon off;` listen 12596; includes `conf.d/{alias}/upstreams.conf` (http block) + `locations.conf` (server block) per coordinator |
-| `Dockerfile` | Alpine 3.23; installs socat + nginx; `COPY . .`; `EXPOSE 12596`; broken HEALTHCHECK (see Traps); `CMD ["sh", "robosats-client.sh"]` |
+| `Dockerfile` | Alpine 3.23; installs socat + nginx; `COPY . .`; `EXPOSE 12596`; HEALTHCHECK uses `wget` (BusyBox); `CMD ["sh", "robosats-client.sh"]` |
 | `docker-compose.yml` | **Dev-only** — builds `../frontend` + `../docker/tor` locally; references non-existent `../node/tor/*` path (see Traps) |
 | `docker-compose-example.yml` | **End-user reference** — has both `build: .` and `image: recksato/robosats-client:latest` (see Traps); ports published on the `tor` service |
 | `coordinators/` | One subdirectory per coordinator with `upstreams.conf` + `locations.conf` |
@@ -97,9 +97,9 @@ The CI `push`/`pull_request` path filter is `paths: ["frontend", "nodeapp"]` —
   responsibility.
 
 ## Traps
-- **`curl` is not installed** in the Alpine image (only `socat` + `nginx`). The Dockerfile
-  `HEALTHCHECK CMD curl --fail http://localhost:12596/selfhosted` always fails/errors.
-  Known issue; replace with `wget -q -O- …` or remove the healthcheck.
+- **HEALTHCHECK uses `wget`** (BusyBox, ships with Alpine) against `/selfhosted`. `curl`
+  is not installed in the image; the previous `curl --fail …` command was always failing.
+  Fixed in this codebase; do not replace `wget` with `curl` without adding a curl install.
 - **Port 12596 is published by the `tor` service**, not by the `nodeapp` service. Because
   `nodeapp` uses `network_mode: service:tor`, it shares the tor container's network
   namespace. The `ports:` mapping in `docker-compose-example.yml` must be on the `tor`
@@ -140,7 +140,7 @@ The CI `push`/`pull_request` path filter is `paths: ["frontend", "nodeapp"]` —
 - When adding a coordinator: update `robosats-client.sh` (unique port pair), create
   `coordinators/{alias}/upstreams.conf` + `locations.conf`, and `include` both in
   `nginx.conf`. See `nodeapp/coordinators/AGENTS.md` for the full procedure.
-- Do not add a `curl` install to the Dockerfile without also fixing the healthcheck CMD
-  to match a real endpoint — or replace with `wget` which Alpine ships.
+- Do not replace `wget` in the HEALTHCHECK with `curl` — `curl` is not installed; use
+  `wget -q -O-` (BusyBox, ships with Alpine) or install `curl` explicitly.
 - Do not assume `nodeapp` sets `network_mode: bridge` — it shares the `tor` service's
   network namespace; any port mapping must live on the `tor` service.

--- a/nodeapp/Dockerfile
+++ b/nodeapp/Dockerfile
@@ -21,6 +21,6 @@ RUN apk -U --no-cache upgrade \
     && apk --no-cache add nginx
 
 EXPOSE 12596
-HEALTHCHECK CMD curl --fail http://localhost:12596/selfhosted || exit 1
+HEALTHCHECK CMD wget -q -O- http://localhost:12596/selfhosted || exit 1
 
 CMD ["sh", "robosats-client.sh"]

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -80,9 +80,8 @@ also emits `nodeapp/basic.html`, `nodeapp/pro.html`, `desktopApp/index.html`, et
 - **`/pro` is a first-class route** — same bundle, pro entry point.
 
 ## Traps
-- **`curl` is not installed** in the Alpine image; the Dockerfile
-  `HEALTHCHECK CMD curl --fail http://localhost:80` always fails. Replace with
-  `wget -q -O- …` or remove the HEALTHCHECK.
+- **HEALTHCHECK uses `wget`** (BusyBox, ships with Alpine). `curl` is not installed;
+  the previous `curl --fail …` command always failed. Fixed in this codebase.
 - **Stale Dockerfile comment**: `# Needs a copy or symlink of /frontend/static in /nodeapp/static` —
   copy-paste from nodeapp; this is the `/web` container, not `/nodeapp`.
 - `basic.html` and `pro.html` are gitignored — any copy in the working tree is a local

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -19,6 +19,6 @@ RUN apk -U --no-cache upgrade \
     && apk --no-cache add nginx
 
 EXPOSE 80
-HEALTHCHECK CMD curl --fail http://localhost:80 || exit 1
+HEALTHCHECK CMD wget -q -O- http://localhost:80 || exit 1
 
 CMD ["sh", "run.sh"]


### PR DESCRIPTION
Both nodeapp/Dockerfile and web/Dockerfile used curl in their HEALTHCHECK instructions, but curl is not installed in either Alpine image (only socat+nginx / nginx are installed). This caused containers to be permanently reported as 'unhealthy' by Docker/orchestrators, which can block startup gating or rolling deployments.

Fix: replace 'curl --fail <url>' with 'wget -q -O- <url>' — BusyBox wget ships with Alpine by default and does not require an extra package. The probe endpoints are unchanged (/selfhosted for nodeapp, / for web).

## What does this PR do?
Fixes #<ISSUE_NUMBER>

This PR introduces/refactors/...

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.