### PR TITLE
Upgrae django and pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-django==5.2.15
+django==5.2.17
 django-admin-relation-links==0.2.5
 django-celery-beat==2.8.1
 django-celery-results==2.6.0
@@ -12,7 +12,7 @@ grpcio==1.67.0
 googleapis-common-protos==1.70.0
 grpcio-tools==1.67.0
 numpy==1.26.4
-Pillow==12.2.0
+Pillow==12.3.0
 python-decouple==3.8
 requests==2.33.0
 ring==0.10.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,4 +2,4 @@ ruff==0.13.1
 coverage==7.10.1
 git+https://github.com/Reckless-Satoshi/drf-openapi-tester.git@soften-django-requirements
 pre-commit==4.2.0
-python-dotenv[cli]==1.1.1
+python-dotenv[cli]==1.2.2


### PR DESCRIPTION
## What does this PR do?

- `django`: `5.2.15` → `5.2.17` — fixes 3 CVEs (cache middleware info leak, HTTP header injection via `DomainNameValidator`, `GDALRaster` heap over-read)
- `Pillow`: `12.2.0` → `12.3.0` — fixes 13 CVEs including heap OOB writes in core image ops, OS command injection in `WindowsViewer`, and multiple decompression-bomb DoS paths

__`requirements_dev.txt`__

- `python-dotenv[cli]`: `1.1.1` → `1.2.2` — fixes CVE-2026-28684 (symlink-following arbitrary file overwrite in `set_key`)

No code changes were required — all three are drop-in patch-level upgrades within their current major series. Pillow's `ImageField` usage in `api/models/robot.py` is purely via Django's ORM with internally generated avatars (no user-supplied image parsing), so the attack surface for the fixed CVEs is minimal in this project but the update is still correct. No Django migrations are expected for a 5.2.x patch bump. No other files in the repository referenced the old version numbers.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.