### PR TITLE
Bump numpy 2.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ celery==5.6.3
 grpcio==1.67.0
 googleapis-common-protos==1.75.1
 grpcio-tools==1.67.0
-numpy==1.26.4
+numpy==2.5.2
 Pillow==12.3.0
 python-decouple==3.8
 requests[socks]==2.34.2


### PR DESCRIPTION
## What does this PR do?

- Audited every numpy call site in the codebase: `api/utils.py` (`np.nan`, `np.nanmedian`, `np.array`, `np.median`, `np.ones`, `np.all`, `np.argsort`, `np.cumsum`, `np.interp`) and `api/tests/test_utils.py` (`np.median`) — no deprecated NumPy 1.x aliases (`np.bool`, `np.int`, `np.str`, etc.) are used anywhere.

- Installed `numpy==2.5.2` — pip pulled the native `cp313-cp313-manylinux` wheel directly (no sdist compilation), confirming the Python 3.13 wheel gap is resolved.

- Ran every numpy code path from both files in isolation: all results are identical to 1.x behaviour (`weighted_median(0.5) = 3.0`, `nanmedian` cross-API median = 10000.5, etc.).

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.