### PR TITLE
Bump Redis 7.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ django-admin-relation-links==0.2.5
 django-celery-beat==2.9.0
 django-celery-results==2.6.0
 django-model-utils==5.0.0
-django-redis==6.0.0
+django-redis==7.0.0
 djangorestframework==3.18.0
 channels==4.3.2
 channels-redis==4.3.0
@@ -31,4 +31,4 @@ pygeohash==3.3.1
 asgiref==3.12.1
 secp256k1==0.14.0
 idna==3.18
-redis==7.4.1
+redis==8.1.0


### PR DESCRIPTION
## What does this PR do?

- `redis==7.4.1` → `redis==8.1.0`
- `django-redis==6.0.0` → `django-redis==7.0.0`

__Compatibility audit (no other files required changes):__

- `robosats/settings.py` `CACHES` block reviewed — no `IGNORE_EXCEPTIONS` key present (the one breaking change in django-redis 7.0); `CLIENT_CLASS: django_redis.client.DefaultClient` remains valid.
- No direct `redis.Redis` / `redis.StrictRedis` instantiation exists anywhere in Python source — all Redis access flows through the `django_redis` cache backend and the `channels_redis` channel layer.
- Celery broker uses `REDIS_URL` as a plain string URL (`app.conf.broker_url`), which redis-py 8.x handles identically.
- Redis server image in `docker-compose.yml` is `redis:6.2.6` — redis-py 8.x minimum server requirement is ≥ 6.2 ✅. Test stack (`docker-tests.yml`) uses `redis:7.2.1` ✅.
- `channels-redis==4.3.0` requires `redis>=4.0`, fully compatible with redis 8.x ✅.


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.