### PR TITLE
Bump nostr-tools 0.45.0

### DIFF
--- a/api/nostr.py
+++ b/api/nostr.py
@@ -4,7 +4,16 @@ import uuid
 
 from secp256k1 import PrivateKey
 from asgiref.sync import sync_to_async
-from nostr_sdk import Keys, Client, EventBuilder, NostrSigner, Kind, Tag, PublicKey
+from nostr_sdk import (
+    Keys,
+    Client,
+    EventBuilder,
+    NostrSigner,
+    Kind,
+    Tag,
+    PublicKey,
+    nip17_make_private_msg_async,
+)
 from api.models import Order
 from decouple import config
 
@@ -25,7 +34,8 @@ class Nostr:
         print("Sending nostr ORDER event")
 
         keys = Keys.parse(config("NOSTR_NSEC", cast=str))
-        client = await self.initialize_client(keys)
+        signer = NostrSigner.keys(keys)
+        client = await self.initialize_client()
 
         robot_name = await self.get_user_name(order)
         robot_hash_id = await self.get_robot_hash_id(order)
@@ -33,10 +43,10 @@ class Nostr:
 
         content = order.description if order.description is not None else ""
 
-        event = (
+        event = await (
             EventBuilder(Kind(38383), content)
             .tags(self.generate_tags(order, robot_name, robot_hash_id, currency))
-            .sign_with_keys(keys)
+            .finalize_async(signer)
         )
         await client.send_event(event)
         print(f"Nostr ORDER event sent: {event.as_json()}")
@@ -49,9 +59,10 @@ class Nostr:
         print("Sending nostr NOTIFICATION event")
 
         keys = Keys.parse(config("NOSTR_NSEC", cast=str))
-        client = await self.initialize_client(keys)
+        signer = NostrSigner.keys(keys)
+        client = await self.initialize_client()
 
-        tags = [
+        rumor_extra_tags = [
             Tag.parse(
                 [
                     "order_id",
@@ -61,13 +72,18 @@ class Nostr:
             Tag.parse(["status", str(order.status)]),
         ]
 
-        await client.send_private_msg(PublicKey.parse(robot.nostr_pubkey), text, tags)
+        gift_wrap = await nip17_make_private_msg_async(
+            signer,
+            PublicKey.parse(robot.nostr_pubkey),
+            text,
+            rumor_extra_tags=rumor_extra_tags,
+        )
+        await client.send_event(gift_wrap)
         print("Nostr NOTIFICATION event sent")
 
-    async def initialize_client(self, keys):
-        # Initialize with coordinator Keys
-        signer = NostrSigner.keys(keys)
-        client = Client(signer)
+    async def initialize_client(self):
+        # Initialize a bare client (no signer needed on the client itself)
+        client = Client()
 
         # Add relays and connect
         strfry_host = config("STRFRY_HOST", cast=str, default="localhost")

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ drf-spectacular==0.30.0
 drf-spectacular-sidecar==2025.12.1
 django-cors-headers==4.9.0
 base91==1.0.1
-nostr-sdk==0.42.1
+nostr-sdk==0.45.0
 pygeohash==3.3.1
 asgiref==3.12.1
 secp256k1==0.14.0


### PR DESCRIPTION
## What does this PR do?

__`nostr-sdk` upgraded from 0.42.1 → 0.45.0.__

Three breaking API changes were identified by inspecting the installed 0.45.0 wheel's stub file and applied to `api/nostr.py`:

1. __`EventBuilder.sign_with_keys(keys)` removed__ → replaced with `await builder.finalize_async(signer)`. A `NostrSigner` is now created explicitly via `NostrSigner.keys(keys)` and passed to `finalize_async`.

2. __`Client(signer)` constructor removed__ → `Client()` now takes no arguments. The signer is no longer stored on the client; it's passed directly to the signing primitives.

3. __`client.send_private_msg(pubkey, text, tags)` removed__ → replaced with the module-level `await nip17_make_private_msg_async(signer, receiver, message, rumor_extra_tags=[...])`, which returns a gift-wrapped NIP-17 `Event` that is then sent via `client.send_event(event)`.


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.