### PR TITLE
Bump gunicorn 26.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ Pillow==12.3.0
 python-decouple==3.8
 requests[socks]==2.34.2
 ring==0.10.1
-gunicorn==23.0.0
+gunicorn==26.0.0
 psycopg2==2.9.12
 django-import-export==4.4.1
 shapely==2.1.2


### PR DESCRIPTION
## What does this PR do?

`gunicorn` 23.0.0 → 26.0.0

__Audit findings before applying:__

- `scripts/entrypoint.sh` uses only `exec "$@"` — no gunicorn flags embedded there.
- `Dockerfile` `CMD` uses `python3 manage.py runserver` (dev default) — no gunicorn invocation.
- `docker-compose.yml` uses `python3 -u manage.py runserver` — no gunicorn invocation.
- Full codebase search across `*.py`, `*.sh`, `*.yml`, `*.md` returned __zero gunicorn CLI invocations__. Gunicorn is installed as a binary in the image; production operators pass their own `CMD` (e.g. `gunicorn robosats.wsgi --bind 0.0.0.0:8000`) which flows through `ENTRYPOINT exec "$@"`.
- CLI surface audit of `gunicorn/config.py` at 26.0.0 confirmed all standard flags (`--bind`, `--workers`, `--worker-class`, `--timeout`, `--graceful-timeout`) are present and unchanged — no deprecated argument syntax to fix.


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.