### PR TITLE
Bump sidecar 2026.08.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ shapely==2.1.2
 python-gnupg==0.5.6
 daphne==4.2.3
 drf-spectacular==0.30.0
-drf-spectacular-sidecar==2025.12.1
+drf-spectacular-sidecar==2026.8.1
 django-cors-headers==4.9.0
 base91==1.0.1
 nostr-sdk==0.42.1


### PR DESCRIPTION
## What does this PR do?

`drf-spectacular-sidecar` bumped from `2025.12.1` → `2026.8.1`.

__Audit summary:__

- Pure static-asset package (bundles Swagger UI + ReDoc JS/CSS for `collectstatic`). Zero Python API surface.
- Only integration points are `"drf_spectacular_sidecar"` in `INSTALLED_APPS` and the `"SIDECAR"` string shorthands in `SPECTACULAR_SETTINGS` — both unchanged across all calver releases.
- PyPI metadata confirms `Requires-Dist: ['Django>=2.2']` only; no `drf-spectacular` constraint. Fully compatible with `drf-spectacular==0.30.0`.
- No code or configuration changes required — pure version pin update.


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.