### PR TITLE
Secutirty audit hygiene

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # Python backend (requirements.txt + requirements_dev.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "backend"
+
+  # Frontend (frontend/package.json)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "frontend"
+
+  # Electron desktop app (desktopApp/package.json)
+  - package-ecosystem: "npm"
+    directory: "/desktopApp"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "desktop"
+
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 ruff==0.16.2
 coverage==7.15.4
-git+https://github.com/Reckless-Satoshi/drf-openapi-tester.git@soften-django-requirements
+git+https://github.com/Reckless-Satoshi/drf-openapi-tester.git@2af4d20743439444054c5bf8a02c9f299b14491f
 pre-commit==4.6.2
 python-dotenv[cli]==1.2.2


### PR DESCRIPTION
## What does this PR do?

— `drf-openapi-tester` commit SHA pin__ (`requirements_dev.txt`):

- Changed `@soften-django-requirements` (branch/tag name) → `@2af4d20743439444054c5bf8a02c9f299b14491f` (full commit SHA). The remote ref turned out to be a tag (not a branch), but pinning to the SHA is still the more explicit and supply-chain-safe form.

— `.github/dependabot.yml` created__:

- Added weekly Dependabot checks for 4 ecosystems: `pip` (backend, `/`), `npm` (`/frontend`), `npm` (`/desktopApp`), and `github-actions` (`/`). Each entry has appropriate labels for triage.


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.