### PR TITLE
Bump CI workflows

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -31,7 +31,7 @@ linters, CodeQL scanning, and a weekly third-party data sync.
 | `mobile-web.bundle` | `android/app/src/main/assets` | `android-build` |
 
 `frontend-build.yml` uses Node **16.17.0** + `NODE_OPTIONS=--max-old-space-size=4096`.
-All 5 uploads use `actions/upload-artifact@v4`.
+All 5 uploads use `actions/upload-artifact@v7`.
 
 ## Pre-release Fan-out (non-release only)
 When `inputs.semver == ''` (i.e. a plain push to `main`, not a tag release),
@@ -60,7 +60,7 @@ When `inputs.semver == ''` (i.e. a plain push to `main`, not a tag release),
 
 Tag set (all three): `type=ref,event=pr`, `type=ref,event=tag`,
 `type=semver,pattern={{major}}.{{minor}}`, `type=sha,priority=100,format=short`,
-`type=raw,value=latest`. Uses `docker/metadata-action@v5` + `docker/build-push-action@v6`.
+`type=raw,value=latest`. Uses `docker/metadata-action@v6` + `docker/build-push-action@v7`.
 
 ## Android Build (`android-build.yml`)
 - Node: N/A; Gradle cache on `~/.gradle/caches`.
@@ -82,7 +82,7 @@ Tag set (all three): `type=ref,event=pr`, `type=ref,event=tag`,
 
 ## lnproxy Sync (`lnproxy-sync.yml`)
 - Weekly (Sundays 12:00 UTC): curls live relay list → `node ./scripts/lnproxy-sync.js` →
-  `peter-evans/create-pull-request@v6` with branch `lnproxy-{date}`, `delete-branch: true`.
+  `peter-evans/create-pull-request@v8` with branch `lnproxy-{date}`, `delete-branch: true`.
 - **Never auto-commits to `main`** — always a PR so a maintainer reviews third-party data.
 
 ## Product Intent
@@ -117,7 +117,7 @@ Tag set (all three): `type=ref,event=pr`, `type=ref,event=tag`,
 4. **Coverage artifact likely empty**: `integration-tests.yml` uploads `htmlcov/` from the
    runner host, but `coverage html` ran inside the `test-coordinator` Docker container —
    the host directory is empty.
-5. **Dead step in `android-build.yml`**: `kaisugi/action-regex-match@v1.0.1` on `github.ref`
+5. **Dead step in `android-build.yml`**: `kaisugi/action-regex-match@v1.0.2` on `github.ref`
    is run but its output is never consumed by any subsequent step.
 6. **Malformed pre-release APK asset names**: the non-release android path names assets with
    `github.ref` (e.g. `refs/tags/…`) — includes the `refs/…` prefix, producing invalid

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: 'Download Android Web.bundle Artifact (built frontend)'
         if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: frontend-build.yml
           workflow_conclusion: success
@@ -86,7 +86,7 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "34.0.0"
 
-      - uses: kaisugi/action-regex-match@v1.0.1
+      - uses: kaisugi/action-regex-match@v1.0.2
         id: regex-match
         with:
           text: ${{ github.ref }}
@@ -100,7 +100,7 @@ jobs:
       # Create app-universal-release APK artifact asset for Release
       - name: 'Upload universal .apk Artifact'
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-universal-release.apk
           path: android/app/build/outputs/apk/release/app-universal-release-unsigned-signed.apk
@@ -108,7 +108,7 @@ jobs:
       # Create app-arm64-v8a-release APK artifact asset for Release
       - name: 'Upload arm64-v8a .apk Artifact'
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-arm64-v8a-release.apk
           path: android/app/build/outputs/apk/release/app-arm64-v8a-release-unsigned-signed.apk
@@ -116,7 +116,7 @@ jobs:
       # Create app-armeabi-v7a-release APK artifact asset for Release
       - name: 'Upload armeabi-v7a .apk Artifact'
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-armeabi-v7a-release.apk
           path: android/app/build/outputs/apk/release/app-armeabi-v7a-release-unsigned-signed.apk
@@ -124,7 +124,7 @@ jobs:
       # Create app-x86_64-release APK artifact asset for Release
       - name: 'Upload x86_64 .apk Artifact'
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: app-x86_64-release.apk
           path: android/app/build/outputs/apk/release/app-x86_64-release-unsigned-signed.apk

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -99,6 +99,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/coordinator-image.yml
+++ b/.github/workflows/coordinator-image.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: 'Download Basic main.js Artifact'
       if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success
@@ -36,14 +36,14 @@ jobs:
         path: frontend
 
     - name: 'Log in to Docker Hub'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: 'Extract metadata (tags, labels) for Docker'
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: recksato/robosats
         tags: |
@@ -63,7 +63,7 @@ jobs:
         echo ${{ steps.commit.outputs.long }}>"commit_sha"
 
     - name: 'Build and push Docker image'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         push: true

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -25,13 +25,13 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 
       - name: 'Download Basic main.js Artifact'
         if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           workflow: frontend-build.yml
           workflow_conclusion: success
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload macOS Build Artifact
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -101,7 +101,7 @@ jobs:
 
       - name: Upload Windows Build Artifact
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload Linux Build Artifact
         if: inputs.semver != ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -120,7 +120,7 @@ jobs:
       - name: Upload macOS Build Artifact
         id: upload-release-mac-zip-asset
         if: inputs.semver == ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -130,7 +130,7 @@ jobs:
       - name: Upload Windows Build Artifact
         id: upload-release-win-zip-asset
         if: inputs.semver == ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -140,7 +140,7 @@ jobs:
       - name: Upload Linux Build Artifact
         id: upload-release-linux-zip-asset
         if: inputs.semver == ''
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: 'Setup node'
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@v7
       with:
         node-version: 16.17.0
         cache: npm
@@ -48,35 +48,35 @@ jobs:
         cd frontend
         npm run build
     - name: 'Archive Django Static Build Results'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: django-main-static
         path: |
           frontend/static
           frontend/templates/frontend/*.html
     - name: 'Archive Node App Static Build Results'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: nodeapp-main-static
         path: |
           nodeapp/static
           nodeapp/*.html
     - name: 'Archive Desktop App Static Build Results'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: desktop-main-static
         path: |
           desktopApp/static
           desktopApp/*.html
     - name: 'Archive Web Static Build Results'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: web-main-static
         path: |
           web/static
           web/*.html
     - name: 'Archive Mobile Build Results'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: mobile-web.bundle
         path: android/app/src/main/assets

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/checkout@v5
 
     - name: 'Download static files Artifact'
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success
@@ -70,7 +70,7 @@ jobs:
       run: docker save backend-image | gzip > backend-image.tar.gz
 
     - name: 'Upload coordinator image artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: backend-image-${{ github.run_id }}
         path: backend-image.tar.gz
@@ -93,7 +93,7 @@ jobs:
       uses: actions/checkout@v5
 
     - name: 'Download static files Artifact'
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success
@@ -148,7 +148,7 @@ jobs:
         USE_TOR: False
 
     - name: 'Upload coverage report'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report-${{ matrix.python-tag }}-${{ matrix.ln-vendor }}-${{ github.run_id }}
         path: htmlcov/

--- a/.github/workflows/js-linter.yml
+++ b/.github/workflows/js-linter.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: 'Setup node'
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v7
         with:
           node-version: 20.20.0
           cache: npm

--- a/.github/workflows/lnproxy-sync.yml
+++ b/.github/workflows/lnproxy-sync.yml
@@ -33,7 +33,7 @@ jobs:
         run: echo "current_date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Submit pull request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "Update LNProxy relay list on ${{ env.current_date }}"
           committer: GitHub Action <action@github.com>

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Release
         id: create-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release_notes.md
           generate_release_notes: true

--- a/.github/workflows/selfhosted-client-image.yml
+++ b/.github/workflows/selfhosted-client-image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: 'Download Basic main.js Artifact'
       if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success
@@ -42,14 +42,14 @@ jobs:
         path: nodeapp
 
     - name: 'Log in to Docker Hub'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: 'Extract metadata (tags, labels) for Docker'
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: recksato/robosats-client
         tags: |
@@ -70,7 +70,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: 'Build and push Docker image'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ./nodeapp
         platforms: linux/amd64,linux/arm64

--- a/.github/workflows/web-client-image.yml
+++ b/.github/workflows/web-client-image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: 'Download Basic main.js Artifact'
       if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-      uses: dawidd6/action-download-artifact@v11
+      uses: dawidd6/action-download-artifact@v21
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success
@@ -42,14 +42,14 @@ jobs:
         path: web
 
     - name: 'Log in to Docker Hub'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: 'Extract metadata (tags, labels) for Docker'
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: recksato/robosats-web
         tags: |
@@ -70,7 +70,7 @@ jobs:
       uses: docker/setup-buildx-action@v3
 
     - name: 'Build and push Docker image'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ./web
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
## What does this PR do?

__— Artifact pipeline__ (must move together): `actions/upload-artifact` bumped v4→v7 at __17 call sites__ across `frontend-build.yml`, `android-build.yml`, `desktop-build.yml`, and `integration-tests.yml`; `dawidd6/action-download-artifact` bumped v11→v21 at __7 call sites__ across `android-build.yml`, `desktop-build.yml`, `coordinator-image.yml`, `selfhosted-client-image.yml`, `web-client-image.yml`, and `integration-tests.yml` (×2). The `actions/download-artifact@v4/v5` sites are untouched — those are separate per the triage spec.

— Independent bumps__: `github/codeql-action` v3→v4 (`codeql.yml`), `docker/login-action` v3→v4 (3 docker image workflows), `docker/metadata-action` v5→v6 (3 docker image workflows), `docker/build-push-action` v6→v7 (3 docker image workflows), `actions/setup-node` v5→v7 (`frontend-build.yml`, `desktop-build.yml`, `js-linter.yml`), `softprops/action-gh-release` v2→v3 (`release.yml`), `kaisugi/action-regex-match` v1.0.1→v1.0.2 (`android-build.yml`).

— Isolated__: `peter-evans/create-pull-request` v6→v8 (`lnproxy-sync.yml`).

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.