### PR TITLE
Fix: Use RelayUrl in nostr add_relay

### DIFF
--- a/api/nostr.py
+++ b/api/nostr.py
@@ -11,6 +11,7 @@ from nostr_sdk import (
     Kind,
     Tag,
     PublicKey,
+    RelayUrl,
     nip17_make_private_msg_async,
 )
 from api.models import Order
@@ -87,7 +88,7 @@ class Nostr:
         # Add relays and connect
         strfry_host = config("STRFRY_HOST", cast=str, default="localhost")
         strfry_port = config("STRFRY_PORT", cast=str, default="7778")
-        await client.add_relay(f"ws://{strfry_host}:{strfry_port}")
+        await client.add_relay(RelayUrl.parse(f"ws://{strfry_host}:{strfry_port}"))
         await client.connect()
 
         return client

--- a/api/tests/test_nostr.py
+++ b/api/tests/test_nostr.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import TestCase
 
-from nostr_sdk import Keys
+from nostr_sdk import Keys, RelayUrl
 
 from api.nostr import Nostr
 from api.models import Order
@@ -478,7 +478,9 @@ class TestNostrSendOrderEvent(TestCase):
         patch_cls, mock_client = _patch_client()
         with patch_cls:
             asyncio.run(self.nostr.send_order_event(order))
-        mock_client.add_relay.assert_called_once_with("ws://relay.mycoord.onion:9000")
+        mock_client.add_relay.assert_called_once_with(
+            RelayUrl.parse("ws://relay.mycoord.onion:9000")
+        )
 
     @patch("api.nostr.config")
     def test_event_is_signed_by_coordinator_key(self, mock_config):
@@ -646,4 +648,6 @@ class TestNostrInitializeClient(TestCase):
         patch_cls, mock_client = _patch_client()
         with patch_cls:
             asyncio.run(self.nostr.initialize_client())
-        mock_client.add_relay.assert_called_once_with("ws://localhost:7778")
+        mock_client.add_relay.assert_called_once_with(
+            RelayUrl.parse("ws://localhost:7778")
+        )


### PR DESCRIPTION
## What does this PR do?

After bumping nostr-sdk to 0.45.0, Client.add_relay no longer accepts a plain string — it requires a RelayUrl. Celery tasks nostr_send_order_event / nostr_send_notification_event were crashing with TypeError: Expected RelayUrl instance, str found when publishing order events to the strfry relay. Wrap the ws://{host}:{port} URL with RelayUrl.parse(...) in Nostr.initialize_client and update the mocked tests to assert against the parsed RelayUrl.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.