### PR TITLE
Remove coordinator unreachable error banner

### DIFF
--- a/frontend/src/services/api/ApiAndroidClient/index.ts
+++ b/frontend/src/services/api/ApiAndroidClient/index.ts
@@ -55,7 +55,6 @@ class ApiAndroidClient implements ApiClient {
       return this.parseResponse(result);
     } catch (error) {
       console.error('API Error:', error);
-      if (!silent) dispatchError('Coordinator unreachable! Please check your connection.');
       throw error;
     }
   }

--- a/frontend/src/services/api/ApiWebClient/index.ts
+++ b/frontend/src/services/api/ApiWebClient/index.ts
@@ -47,7 +47,6 @@ class ApiWebClient implements ApiClient {
       return await response.json();
     } catch (error) {
       console.error('API Error:', error);
-      if (!silent) dispatchError('Coordinator unreachable! Please check your connection.');
       throw error;
     }
   }


### PR DESCRIPTION
Removes the dispatcher error message for coordinator unreachable cases. The error is already thrown and handled by the caller, so the redundant dispatchError call is unnecessary.