### PR TITLE
Add testnet relay routes to nodeapp

### DIFF
--- a/nodeapp/AGENTS.md
+++ b/nodeapp/AGENTS.md
@@ -119,8 +119,11 @@ The CI `push`/`pull_request` path filter is `paths: ["frontend", "nodeapp"]` —
   testnet is effectively absent for those three.
 - **All five `locations.conf` testnet avatar routes** now use `/testnet/{alias}/...`
   consistent with the API/WS routes — fixed in this codebase.
-- **No `/testnet/{alias}/relay/`** route exists in any coordinator config — testnet Nostr
-  relay is unreachable through nodeapp.
+- **All five `locations.conf` now include `/testnet/{alias}/relay/`** — testnet Nostr
+  relay is reachable through nodeapp (mirrors the mainnet relay route, including the
+  `Origin $http_origin` proxy header and `Access-Control-Allow-Origin: *`). Note: bazaar,
+  freedomsats, and alice reuse their mainnet onion for testnet, so their relay serves both
+  networks — the client filters order events by the `network` tag.
 - **`basic.html` / `pro.html` in the working tree** are local dev outputs — they may pin
   an old bundle version (e.g., v0.8.4 while `static/frontend/` contains v0.8.5). CI
   always injects the correct artifact; never rely on committed HTML.

--- a/nodeapp/coordinators/AGENTS.md
+++ b/nodeapp/coordinators/AGENTS.md
@@ -40,9 +40,7 @@ Both upstream names must match exactly what `locations.conf` references in `prox
 | `/testnet/{alias}/static/assets/avatars/` | `testnet_{alias}` | Coordinator avatar images (testnet) |
 | `/testnet/{alias}/api/` | `testnet_{alias}` | |
 | `/testnet/{alias}/ws/` | `testnet_{alias}` | |
-
-**Missing**: no `/testnet/{alias}/relay/` location in any coordinator config — testnet
-Nostr relay is unreachable through nodeapp.
+| `/testnet/{alias}/relay/` | `testnet_{alias}` | Nostr relay; same upgrade headers + `Origin $http_origin` + `Access-Control-Allow-Origin *` as the mainnet relay |
 
 ## CORS Policy
 - API and WS routes carry **no CORS headers** — all traffic is same-origin through Nginx;
@@ -76,9 +74,10 @@ Reverse of the above: remove socat lines from `robosats-client.sh`, delete the
   not a runtime-fetched list. Generating this config automatically from
   `federation.json` is a known improvement path but has not been implemented.
 - **Testnet support in nodeapp is best-effort.** Three of five coordinators (bazaar,
-  freedomsats, alice) share a single onion for mainnet and testnet; no testnet relay route
-  exists. Testnet is functionally degraded in this container — usable for API/WS only on
-  the coordinators with distinct testnet onions (temple, lake).
+  freedomsats, alice) share a single onion for mainnet and testnet, so their testnet
+  traffic (API, WS, and relay) hits the mainnet service — the coordinator must distinguish
+  them server-side. Only temple and lake have distinct testnet onions with a real testnet
+  relay.
 
 ## Traps
 - `coordinators/alice/upstreams.conf` comments say "Libre Bazaar" (copy-paste error) and
@@ -91,8 +90,9 @@ Reverse of the above: remove socat lines from `robosats-client.sh`, delete the
   completely unreachable in any running `:latest` container.**
 - All five `locations.conf` testnet avatar routes now use `/testnet/{alias}/...`
   consistent with the API/WS routes — fixed in this codebase.
-- No testnet `relay/` route exists in any coordinator config — testnet Nostr relay is
-  unreachable through nodeapp.
+- All five `locations.conf` now include a `/testnet/{alias}/relay/` route — fixed in this
+  codebase. For bazaar/freedomsats/alice the route proxies to the shared onion, so the
+  same relay serves mainnet and testnet events (the client filters by `network` tag).
 - `coordinators/freedomsats/upstreams.conf` comments say "Libre freedomsats" — another
   copy-paste artefact; functionally harmless but misleading.
 - Several `locations.conf` comments name the wrong coordinator (e.g., lake's testnet

--- a/nodeapp/coordinators/alice/locations.conf
+++ b/nodeapp/coordinators/alice/locations.conf
@@ -68,3 +68,14 @@ location /testnet/alice/ws/ {
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;
 }
+
+location /testnet/alice/relay/ {
+    proxy_pass http://testnet_alice/relay/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Origin $http_origin;
+    proxy_set_header Host $host;
+
+    add_header Access-Control-Allow-Origin *;
+}

--- a/nodeapp/coordinators/bazaar/locations.conf
+++ b/nodeapp/coordinators/bazaar/locations.conf
@@ -68,3 +68,14 @@ location /testnet/bazaar/ws/ {
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;
 }
+
+location /testnet/bazaar/relay/ {
+    proxy_pass http://testnet_bazaar/relay/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Origin $http_origin;
+    proxy_set_header Host $host;
+
+    add_header Access-Control-Allow-Origin *;
+}

--- a/nodeapp/coordinators/freedomsats/locations.conf
+++ b/nodeapp/coordinators/freedomsats/locations.conf
@@ -68,3 +68,14 @@ location /testnet/freedomsats/ws/ {
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;
 }
+
+location /testnet/freedomsats/relay/ {
+    proxy_pass http://testnet_freedomsats/relay/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Origin $http_origin;
+    proxy_set_header Host $host;
+
+    add_header Access-Control-Allow-Origin *;
+}

--- a/nodeapp/coordinators/lake/locations.conf
+++ b/nodeapp/coordinators/lake/locations.conf
@@ -68,3 +68,14 @@ location /testnet/lake/ws/ {
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;
 }
+
+location /testnet/lake/relay/ {
+    proxy_pass http://testnet_lake/relay/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Origin $http_origin;
+    proxy_set_header Host $host;
+
+    add_header Access-Control-Allow-Origin *;
+}

--- a/nodeapp/coordinators/temple/locations.conf
+++ b/nodeapp/coordinators/temple/locations.conf
@@ -68,3 +68,14 @@ location /testnet/temple/ws/ {
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;
 }
+
+location /testnet/temple/relay/ {
+    proxy_pass http://testnet_temple/relay/;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Origin $http_origin;
+    proxy_set_header Host $host;
+
+    add_header Access-Control-Allow-Origin *;
+}


### PR DESCRIPTION
## What does this PR do?

In selfhosted deployments, the frontend builds Nostr relay URLs as ws://{host}:12596/{network}/{alias}/relay/. While every coordinator's nginx config proxied the /mainnet/{alias}/relay/ path to its socat bridge, no /testnet/{alias}/relay/ location existed for any of the five coordinators.

Because settings.connection defaults to 'nostr', this left testnet degraded through nodeapp: the relay WebSocket failed to connect (the browser logs WebSocket connection to 'ws://…/testnet/lake/relay/' failed), and since the order book is populated from Nostr kind 38383 events, no orders appeared either. Nostr worked on Android because there relay URLs point directly at the coordinator .onion, which serves the testnet relay.

This PR adds the missing /testnet/{alias}/relay/ location to coordinators/{temple,lake,bazaar,freedomsats,alice}/locations.conf, mirroring the mainnet relay route (proxy upgrade headers, Origin $http_origin, and Access-Control-Allow-Origin *) and pointing at the testnet_{alias} upstream. Temple and Lake resolve to distinct testnet onions with real testnet relays; Bazaar, FreedomSats, and Alice reuse their mainnet onion, so their relay serves both networks — the client already filters order events by the network tag. Docs updated accordingly.

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.