### PR TITLE
Fix Redis 8.x timeout in Channels

### DIFF
--- a/robosats/settings.py
+++ b/robosats/settings.py
@@ -254,7 +254,12 @@ CHANNEL_LAYERS = {
     "default": {
         "BACKEND": "channels_redis.core.RedisChannelLayer",
         "CONFIG": {
-            "hosts": [config("REDIS_URL")],
+            "hosts": [
+                {
+                    "address": config("REDIS_URL"),
+                    "socket_timeout": None,
+                }
+            ],
         },
     },
 }


### PR DESCRIPTION
## What does this PR do?

redis-py 8.0.0 changed default `socket_timeout` from None to 5 seconds. This causes a race condition with Django Channels' blocking Redis commands (BZPOPMIN/BRPOP with 5s server-side timeout), resulting in: `redis.exceptions.TimeoutError: Timeout reading from localhost:6379`

Fix: Set `socket_timeout: None` in CHANNEL_LAYERS config to disable client-side timeout, allowing server-side blocking commands to complete.

Source: https://github.com/redis/redis-py/issues/4091

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.