### PR TITLE
Bump openpgp 6

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,7 +37,7 @@
         "light-bolt11-decoder": "^3.2.0",
         "nostr-tools": "^2.24.1",
         "npm": "^11.4.1",
-        "openpgp": "^5.11.3",
+        "openpgp": "^6.3.1",
         "react": "^19.2.8",
         "react-countdown": "^2.3.6",
         "react-dom": "^19.2.8",
@@ -5558,18 +5558,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -6032,12 +6020,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.5.tgz",
-      "integrity": "sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==",
-      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -9194,6 +9176,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/install": {
@@ -10815,12 +10798,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.5",
@@ -13090,16 +13067,21 @@
       }
     },
     "node_modules/openpgp": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.11.3.tgz",
-      "integrity": "sha512-jXOPfIteBUQ2zSmRG4+Y6PNntIIDEAvoM/lOYCnvpXAByJEruzrHQZWE/0CGOKHbubwUuty2HoPHsqBzyKHOpA==",
-      "deprecated": "This version is deprecated and will no longer receive security patches. Please refer to https://github.com/openpgpjs/openpgpjs/wiki/Updating-from-previous-versions for details on how to upgrade to a newer supported version.",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.1.tgz",
+      "integrity": "sha512-7oSPvmlKPojxFoyelT5DWPIAVmqWZh4qU/5pO6bdoShEtRpCw9Sye9IXUQj6EFM3XpgGssqccAr705YtTcLNQw==",
       "license": "LGPL-3.0+",
-      "dependencies": {
-        "asn1.js": "^5.0.0"
-      },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 18.0.0",
+        "typescript": ">= 5.0.0"
+      },
+      "peerDependencies": {
+        "@openpgp/web-stream-tools": "~0.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@openpgp/web-stream-tools": {
+          "optional": true
+        }
       }
     },
     "node_modules/optionator": {
@@ -14275,12 +14257,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -90,7 +90,7 @@
     "light-bolt11-decoder": "^3.2.0",
     "nostr-tools": "^2.24.1",
     "npm": "^11.4.1",
-    "openpgp": "^5.11.3",
+    "openpgp": "^6.3.1",
     "react": "^19.2.8",
     "react-countdown": "^2.3.6",
     "react-dom": "^19.2.8",


### PR DESCRIPTION
## What does this PR do?

`openpgp` was upgraded from `5.11.3` → `6.3.1` with __zero source code changes__. The v6 high-level API (`generateKey`, `readKey`, `readPrivateKey`, `decryptKey`, `encrypt`, `decrypt`, `createMessage`, `createCleartextMessage`, `readMessage`, `sign`) is identical to v5 for our browser/lightweight use case. The `openpgp/lightweight` subpath is preserved in v6's package exports map, and the peer dep `@openpgp/web-stream-tools@~0.3.0` is optional (only needed for Node.js streams) so it was not installed.

The webpack build confirms a clean result: `webpack 5.109.2 compiled with 2 warnings` — the same 2 pre-existing bundle-size warnings, no new errors. The audit report was fully updated: status table, Section F detail, Security Notes, and Transitive Dependencies all reflect the completed migration.


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.