### PR TITLE
Bump react grid layout 2.2.4

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,7 +41,7 @@
         "react": "^19.2.8",
         "react-countdown": "^2.3.6",
         "react-dom": "^19.2.8",
-        "react-grid-layout": "^1.5.2",
+        "react-grid-layout": "^2.2.4",
         "react-i18next": "^17.0.11",
         "react-image": "^4.1.0",
         "react-leaflet": "^5.0.0",
@@ -13703,16 +13703,16 @@
       }
     },
     "node_modules/react-grid-layout": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-1.5.4.tgz",
-      "integrity": "sha512-AyScMfqhgRfie9ECXddQeaYmTuNlomDj9SIryF/+vtiwXS6IsxX3cI6CCWbSRXqbAePHW397nPxvnekO5gViPg==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-2.2.4.tgz",
+      "integrity": "sha512-Eb57FsgOMYOfsUGrMI1ku/FFR+dPNPrE8qo+3hwZubpqVSy4GO9v52DeX50Tl3JDYAlCypP4rmw7Vrqk/zOIvA==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1",
         "fast-equals": "^4.0.3",
         "prop-types": "^15.8.1",
         "react-draggable": "^4.4.6",
-        "react-resizable": "^3.0.5",
+        "react-resizable": "^3.1.3",
         "resize-observer-polyfill": "^1.5.1"
       },
       "peerDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -94,7 +94,7 @@
     "react": "^19.2.8",
     "react-countdown": "^2.3.6",
     "react-dom": "^19.2.8",
-    "react-grid-layout": "^1.5.2",
+    "react-grid-layout": "^2.2.4",
     "react-i18next": "^17.0.11",
     "react-image": "^4.1.0",
     "react-leaflet": "^5.0.0",

--- a/frontend/src/basic/RobotPage/TokenInput.tsx
+++ b/frontend/src/basic/RobotPage/TokenInput.tsx
@@ -85,24 +85,26 @@ const TokenInput = ({
             onPressEnter();
           }
         }}
-        InputProps={{
-          endAdornment: showCopy ? (
-            <Tooltip open={showCopied} title={t('Copied!')}>
-              <IconButton
-                autoFocus={autoFocusTarget === 'copyButton'}
-                color='inherit'
-                onClick={() => {
-                  systemClient.copyToClipboard(inputToken);
-                  setShowCopied(true);
-                  setTimeout(() => {
-                    setShowCopied(false);
-                  }, 1000);
-                }}
-              >
-                <ContentCopy sx={{ width: '1em', height: '1em' }} />
-              </IconButton>
-            </Tooltip>
-          ) : null,
+        slotProps={{
+          input: {
+            endAdornment: showCopy ? (
+              <Tooltip open={showCopied} title={t('Copied!')}>
+                <IconButton
+                  autoFocus={autoFocusTarget === 'copyButton'}
+                  color='inherit'
+                  onClick={() => {
+                    systemClient.copyToClipboard(inputToken);
+                    setShowCopied(true);
+                    setTimeout(() => {
+                      setShowCopied(false);
+                    }, 1000);
+                  }}
+                >
+                  <ContentCopy sx={{ width: '1em', height: '1em' }} />
+                </IconButton>
+              </Tooltip>
+            ) : null,
+          },
         }}
       />
     );

--- a/frontend/src/components/Dialogs/AuditPGP.tsx
+++ b/frontend/src/components/Dialogs/AuditPGP.tsx
@@ -41,18 +41,20 @@ function CredentialTextfield(props): React.JSX.Element {
           value={props.value}
           variant='filled'
           size='small'
-          InputProps={{
-            endAdornment: (
-              <Tooltip disableHoverListener enterTouchDelay={0} title={props.copiedTitle}>
-                <IconButton
-                  onClick={() => {
-                    systemClient.copyToClipboard(props.value);
-                  }}
-                >
-                  <ContentCopy />
-                </IconButton>
-              </Tooltip>
-            ),
+          slotProps={{
+            input: {
+              endAdornment: (
+                <Tooltip disableHoverListener enterTouchDelay={0} title={props.copiedTitle}>
+                  <IconButton
+                    onClick={() => {
+                      systemClient.copyToClipboard(props.value);
+                    }}
+                  >
+                    <ContentCopy />
+                  </IconButton>
+                </Tooltip>
+              ),
+            },
           }}
         />
       </Tooltip>

--- a/frontend/src/components/Dialogs/StoreToken.tsx
+++ b/frontend/src/components/Dialogs/StoreToken.tsx
@@ -51,18 +51,20 @@ const StoreTokenDialog = ({
             value={garage.getSlot()?.token}
             variant='filled'
             size='medium'
-            InputProps={{
-              endAdornment: (
-                <Tooltip disableHoverListener enterTouchDelay={0} title={t('Copied!')}>
-                  <IconButton
-                    onClick={() => {
-                      systemClient.copyToClipboard(garage.getSlot()?.token ?? '');
-                    }}
-                  >
-                    <ContentCopy color='primary' />
-                  </IconButton>
-                </Tooltip>
-              ),
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <Tooltip disableHoverListener enterTouchDelay={0} title={t('Copied!')}>
+                    <IconButton
+                      onClick={() => {
+                        systemClient.copyToClipboard(garage.getSlot()?.token ?? '');
+                      }}
+                    >
+                      <ContentCopy color='primary' />
+                    </IconButton>
+                  </Tooltip>
+                ),
+              },
             }}
           />
         </Grid>

--- a/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
+++ b/frontend/src/components/TradeBox/Forms/LightningPayout.tsx
@@ -388,27 +388,29 @@ export const LightningPayoutForm = ({
                         : lightning.routingBudgetSats
                     }
                     variant='outlined'
-                    InputProps={{
-                      endAdornment: (
-                        <InputAdornment position='end'>
-                          <Button
-                            variant='text'
-                            onClick={() => {
-                              setLightning({
-                                ...lightning,
-                                routingBudgetUnit:
-                                  lightning.routingBudgetUnit === 'PPM' ? 'Sats' : 'PPM',
-                              });
-                            }}
-                          >
-                            {lightning.routingBudgetUnit}
-                          </Button>
-                        </InputAdornment>
-                      ),
-                    }}
-                    inputProps={{
-                      style: {
-                        textAlign: 'center',
+                    slotProps={{
+                      input: {
+                        endAdornment: (
+                          <InputAdornment position='end'>
+                            <Button
+                              variant='text'
+                              onClick={() => {
+                                setLightning({
+                                  ...lightning,
+                                  routingBudgetUnit:
+                                    lightning.routingBudgetUnit === 'PPM' ? 'Sats' : 'PPM',
+                                });
+                              }}
+                            >
+                              {lightning.routingBudgetUnit}
+                            </Button>
+                          </InputAdornment>
+                        ),
+                      },
+                      htmlInput: {
+                        style: {
+                          textAlign: 'center',
+                        },
                       },
                     }}
                     onChange={onRoutingBudgetChange}
@@ -504,27 +506,29 @@ export const LightningPayoutForm = ({
                               : lightning.lnproxyBudgetSats
                           }
                           variant='outlined'
-                          InputProps={{
-                            endAdornment: (
-                              <InputAdornment position='end'>
-                                <Button
-                                  variant='text'
-                                  onClick={() => {
-                                    setLightning({
-                                      ...lightning,
-                                      lnproxyBudgetUnit:
-                                        lightning.lnproxyBudgetUnit === 'PPM' ? 'Sats' : 'PPM',
-                                    });
-                                  }}
-                                >
-                                  {lightning.lnproxyBudgetUnit}
-                                </Button>
-                              </InputAdornment>
-                            ),
-                          }}
-                          inputProps={{
-                            style: {
-                              textAlign: 'center',
+                          slotProps={{
+                            input: {
+                              endAdornment: (
+                                <InputAdornment position='end'>
+                                  <Button
+                                    variant='text'
+                                    onClick={() => {
+                                      setLightning({
+                                        ...lightning,
+                                        lnproxyBudgetUnit:
+                                          lightning.lnproxyBudgetUnit === 'PPM' ? 'Sats' : 'PPM',
+                                      });
+                                    }}
+                                  >
+                                    {lightning.lnproxyBudgetUnit}
+                                  </Button>
+                                </InputAdornment>
+                              ),
+                            },
+                            htmlInput: {
+                              style: {
+                                textAlign: 'center',
+                              },
                             },
                           }}
                           onChange={onProxyBudgetChange}

--- a/frontend/src/pro/Main.tsx
+++ b/frontend/src/pro/Main.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useCallback, useMemo, useEffect } from 'react';
-import GridLayout, { type Layout } from 'react-grid-layout';
+import GridLayout, { type Layout, type LayoutItem, type EventCallback } from 'react-grid-layout';
 import { Grid, styled, useTheme } from '@mui/material';
 
 import {
@@ -94,27 +94,28 @@ const Main = (): React.JSX.Element => {
     setDrawerOpen((prev) => !prev);
   }, []);
 
-  const handleDragStop = useCallback(
-    (newLayout: Layout) => {
+  // v2 EventCallback: (layout, oldItem, newItem, placeholder, event, element)
+  const handleDragStop = useCallback<EventCallback>(
+    (newLayout) => {
       setLayout(newLayout);
       setIsDragging(false);
     },
     [setLayout],
   );
 
-  const handleResizeStop = useCallback(
-    (newLayout: Layout) => {
+  const handleResizeStop = useCallback<EventCallback>(
+    (newLayout) => {
       setLayout(newLayout);
       setIsDragging(false);
     },
     [setLayout],
   );
 
-  const handleDragStart = useCallback(() => {
+  const handleDragStart = useCallback<EventCallback>(() => {
     setIsDragging(true);
   }, []);
 
-  const handleResizeStart = useCallback(() => {
+  const handleResizeStart = useCallback<EventCallback>(() => {
     setIsDragging(true);
   }, []);
 
@@ -137,7 +138,7 @@ const Main = (): React.JSX.Element => {
       if (layout.some((item) => item.i === widget.id)) return;
 
       const pos = findNextPosition(widget.defaultSize.w, widget.defaultSize.h);
-      const newItem = {
+      const newItem: LayoutItem = {
         i: widget.id,
         x: pos.x,
         y: pos.y,
@@ -190,6 +191,9 @@ const Main = (): React.JSX.Element => {
 
   const currentWidgets = useMemo(() => layout.map((item) => item.i), [layout]);
 
+  const gridWidth = Number((windowSize.width / gridCellSize).toFixed()) * gridCellSize * em;
+  const gridCols = Number((windowSize.width / gridCellSize).toFixed());
+
   return (
     <Router>
       <Grid container sx={{ width: `${windowSize.width}em`, flexDirection: 'column' }}>
@@ -221,24 +225,28 @@ const Main = (): React.JSX.Element => {
         <Grid item>
           <StyledRGL
             gridHeight={windowSize.height - toolbarHeight}
-            width={Number((windowSize.width / gridCellSize).toFixed()) * gridCellSize * em}
+            width={gridWidth}
             className='layout'
-            useCSSTransforms={true}
-            transformScale={1}
             layout={layout}
-            cols={Number((windowSize.width / gridCellSize).toFixed())}
-            margin={[0.5 * em, 0.5 * em]}
-            isDraggable={!isLocked}
-            isResizable={!isLocked}
+            gridConfig={{
+              cols: gridCols,
+              rowHeight: gridCellSize * em,
+              margin: [0.5 * em, 0.5 * em],
+            }}
+            dragConfig={{
+              enabled: !isLocked,
+              cancel: '.noDrag',
+            }}
+            resizeConfig={{
+              enabled: !isLocked,
+            }}
             isDragging={isDragging}
             isLocked={isLocked}
-            rowHeight={gridCellSize * em}
             autoSize={true}
             onDragStart={handleDragStart}
             onDragStop={handleDragStop}
             onResizeStart={handleResizeStart}
             onResizeStop={handleResizeStop}
-            draggableCancel='.noDrag'
           >
             {renderedWidgets}
           </StyledRGL>

--- a/frontend/src/pro/Widgets/Book.tsx
+++ b/frontend/src/pro/Widgets/Book.tsx
@@ -2,11 +2,11 @@ import React, { useContext } from 'react';
 import { AppContext, type UseAppStoreType } from '../../contexts/AppContext';
 import { Paper } from '@mui/material';
 import BookTable from '../../components/BookTable';
-import { type GridItem } from 'react-grid-layout';
+import { type LayoutItem } from 'react-grid-layout';
 import { FederationContext, type UseFederationStoreType } from '../../contexts/FederationContext';
 
 interface BookWidgetProps {
-  layout: GridItem;
+  layout: LayoutItem | undefined;
   gridCellSize?: number;
   style?: React.StyleHTMLAttributes<HTMLElement>;
   className?: string;
@@ -27,8 +27,8 @@ const BookWidget = React.forwardRef(function Component({
       <Paper elevation={3} style={{ width: '100%', height: '100%' }}>
         <BookTable
           elevation={0}
-          maxWidth={layout.w * gridCellSize} // EM units
-          maxHeight={layout.h * gridCellSize} // EM units
+          maxWidth={(layout?.w ?? 0) * gridCellSize} // EM units
+          maxHeight={(layout?.h ?? 0) * gridCellSize} // EM units
           fullWidth={windowSize.width} // EM units
           fullHeight={windowSize.height} // EM units
           defaultFullscreen={false}

--- a/frontend/src/pro/Widgets/Depth.tsx
+++ b/frontend/src/pro/Widgets/Depth.tsx
@@ -2,11 +2,11 @@ import React, { useContext } from 'react';
 import { AppContext, type UseAppStoreType } from '../../contexts/AppContext';
 import { Paper } from '@mui/material';
 import DepthChart from '../../components/Charts/DepthChart';
-import { type Layout } from 'react-grid-layout';
+import { type LayoutItem } from 'react-grid-layout';
 import { FederationContext, type UseFederationStoreType } from '../../contexts/FederationContext';
 
 interface DepthChartWidgetProps {
-  layout: Layout;
+  layout: LayoutItem | undefined;
   gridCellSize: number;
   style?: React.StyleHTMLAttributes<HTMLElement>;
   className?: string;
@@ -38,8 +38,8 @@ const DepthChartWidget = React.forwardRef(function Component({
       >
         <DepthChart
           elevation={0}
-          maxWidth={layout.w * gridCellSize}
-          maxHeight={layout.h * gridCellSize}
+          maxWidth={(layout?.w ?? 0) * gridCellSize}
+          maxHeight={(layout?.h ?? 0) * gridCellSize}
           fillContainer={true}
         />
       </Paper>

--- a/frontend/src/pro/Widgets/Federation.tsx
+++ b/frontend/src/pro/Widgets/Federation.tsx
@@ -2,14 +2,14 @@ import React, { useContext, useEffect, useRef, useState } from 'react';
 import { FederationContext, type UseFederationStoreType } from '../../contexts/FederationContext';
 import { AppContext, type UseAppStoreType } from '../../contexts/AppContext';
 import { Paper, Box } from '@mui/material';
-import { type GridItem } from 'react-grid-layout';
+import { type LayoutItem } from 'react-grid-layout';
 import FederationTable from '../../components/FederationTable';
 
 const BASE_WIDTH = 550;
 const MIN_SCALE = 0.5;
 
 interface FederationWidgetProps {
-  layout: GridItem;
+  layout: LayoutItem | undefined;
   gridCellSize: number;
   style?: React.StyleHTMLAttributes<HTMLElement>;
   className?: string;


### PR DESCRIPTION
## What does this PR do?

- __`package.json`__: Bumped `react-grid-layout` from `^1.5.2` → `^2.2.4` (installed: 2.2.4). v2 ships bundled TypeScript types (`dist/index.d.ts`) — v1 had none.

- __`src/pro/Main.tsx`__: Migrated from v1's flat props to v2's grouped config objects:

  - `cols/rowHeight/margin` → `gridConfig={{ cols, rowHeight, margin }}`
  - `isDraggable/draggableCancel` → `dragConfig={{ enabled, cancel }}`
  - `isResizable` → `resizeConfig={{ enabled }}`
  - `useCSSTransforms/transformScale` removed (v2 defaults preserved)
  - Event handlers typed as `EventCallback` (v2's `(layout, oldItem, newItem, placeholder, event, element) => void`)
  - Added `LayoutItem` import for explicit typing of new widget items

- __Type fixes in widget files__ (v1 had no TS types, so these were silently `any`):

  - `Book.tsx` + `Federation.tsx`: `GridItem` (v1's internal React component, not a type) → `LayoutItem | undefined`
  - `Depth.tsx`: `Layout` (array type) incorrectly used for a single item → `LayoutItem | undefined`
  - Added `?.w ?? 0` / `?.h ?? 0` null guards where layout items are accessed


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.