### PR TITLE
Bump webpack-cli 7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -97,7 +97,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^6.0.3",
         "webpack": "^5.109.2",
-        "webpack-cli": "^6.0.1"
+        "webpack-cli": "^7.2.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2084,9 +2084,9 @@
       }
     },
     "node_modules/@discoveryjs/json-ext": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
-      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz",
+      "integrity": "sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5138,53 +5138,6 @@
         "@xtuc/long": "4.2.2"
       }
     },
-    "node_modules/@webpack-cli/configtest": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
-      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/info": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
-      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      }
-    },
-    "node_modules/@webpack-cli/serve": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
-      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "webpack": "^5.82.0",
-        "webpack-cli": "6.x.x"
-      },
-      "peerDependenciesMeta": {
-        "webpack-dev-server": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
@@ -6443,13 +6396,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/colorette": {
-      "version": "2.0.20",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-      "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8329,16 +8275,6 @@
         }
       ],
       "license": "BSD-3-Clause"
-    },
-    "node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
-      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -14066,22 +14002,17 @@
       }
     },
     "node_modules/webpack-cli": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
-      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-7.2.2.tgz",
+      "integrity": "sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@discoveryjs/json-ext": "^0.6.1",
-        "@webpack-cli/configtest": "^3.0.1",
-        "@webpack-cli/info": "^3.0.1",
-        "@webpack-cli/serve": "^3.0.1",
-        "colorette": "^2.0.14",
-        "commander": "^12.1.0",
-        "cross-spawn": "^7.0.3",
-        "envinfo": "^7.14.0",
-        "fastest-levenshtein": "^1.0.12",
-        "import-local": "^3.0.2",
+        "@discoveryjs/json-ext": "^1.1.0",
+        "commander": "^14.0.3",
+        "cross-spawn": "^7.0.6",
+        "envinfo": "^7.21.0",
+        "import-local": "^3.2.0",
         "interpret": "^3.1.1",
         "rechoir": "^0.8.0",
         "webpack-merge": "^6.0.1"
@@ -14090,16 +14021,30 @@
         "webpack-cli": "bin/cli.js"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       },
       "peerDependencies": {
-        "webpack": "^5.82.0"
+        "js-yaml": "^4.0.0 || ^5.0.0",
+        "json5": "^2.2.3",
+        "toml": "^3.0.0 || ^4.0.0",
+        "webpack": "^5.101.0",
+        "webpack-bundle-analyzer": "^4.0.0 || ^5.0.0",
+        "webpack-dev-server": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
+        "js-yaml": {
+          "optional": true
+        },
+        "json5": {
+          "optional": true
+        },
+        "toml": {
+          "optional": true
+        },
         "webpack-bundle-analyzer": {
           "optional": true
         },
@@ -14109,13 +14054,13 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/webpack-merge": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,7 +59,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3",
     "webpack": "^5.109.2",
-    "webpack-cli": "^6.0.1"
+    "webpack-cli": "^7.2.2"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",


### PR DESCRIPTION
## What does this PR do?

Upgraded `webpack-cli` from `^6.0.1` to `^7.2.2` (latest). All v7 breaking changes were assessed and none applied to this project: Node.js minimum is satisfied (v22 > v20.9), `--mode` is used rather than the removed `--node-env`, `webpack.config.ts` still loads via `ts-node`/`interpret` fallback, and `webpack-cli` is never imported programmatically. The build ran cleanly — `webpack 5.109.2 compiled with 2 warnings` (the bundle-size warnings are pre-existing).

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.