### PR TITLE
Fix types https nodeapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -657,6 +657,7 @@ web/static
 web/*.html
 nodeapp/static
 nodeapp/*.html
+nodeapp/ssl
 
 # Protocol Buffers
 api/lightning/*.proto

--- a/nodeapp/.dockerignore
+++ b/nodeapp/.dockerignore
@@ -1,5 +1,6 @@
 README.md
 assets
+ssl
 static/assets/vector
 static/assets/images/Ba*
 static/assets/images/bot*

--- a/nodeapp/AGENTS.md
+++ b/nodeapp/AGENTS.md
@@ -138,7 +138,8 @@ The CI `push`/`pull_request` path filter is `paths: ["frontend", "nodeapp"]` —
   an old bundle version (e.g., v0.8.4 while `static/frontend/` contains v0.8.5). CI
   always injects the correct artifact; never rely on committed HTML.
 - `README.md` is stale: "localhost:81", references an old default onion address, "Future:
-  I2P" (unimplemented), and a WebLN/getAlby note (not an active product feature).
+  I2P" (unimplemented), and a WebLN/getAlby note (not an active product feature). The
+  HTTPS/self-signed-cert warning section is current — keep it in sync with any TLS changes.
 
 ## Constraints
 - Never add a clearnet network path or set `network_mode` to anything other than

--- a/nodeapp/AGENTS.md
+++ b/nodeapp/AGENTS.md
@@ -13,16 +13,18 @@ or `'selfhosted-pro'`.
 
 ## Architecture
 ```
-Host :12596  (published on the tor service — see Traps)
+Host :12596  (HTTPS, self-signed cert — published on the tor service, see Traps)
   └── Nginx  (network_mode: service:tor — shares Tor container's network namespace)
         ├── /                     → SPA (basic.html)
         ├── /pro                  → SPA (pro.html)
         ├── /static/              → filesystem alias /usr/src/robosats/static/ (autoindex on)
         ├── /favicon.ico          → filesystem alias /usr/src/robosats/static/assets/images/favicon-32x32.png
-        ├── /selfhosted           → 200 OK (container healthcheck probe)
+        ├── (plain HTTP on :12596 → 301 https via error_page 497)
         └── /mainnet/{alias}/...
         └── /testnet/{alias}/...  → socat upstreams (127.0.0.1:{port})
               └── socat tcp4-LISTEN:{port} … SOCKS5-CONNECT:{Tor}:{onion}:80
+
+Internal (not published): 127.0.0.1:8080/selfhosted → 200 OK (container healthcheck probe)
 ```
 
 `network_mode: service:tor` is **mandatory** — all egress exits through Tor.
@@ -31,14 +33,15 @@ No clearnet path exists; no I2P fallback is implemented.
 ## Key Files
 | File | Role |
 |---|---|
-| `robosats-client.sh` | Starts 12 socat bridges (2 per coordinator: mainnet + testnet) then `nginx` in foreground |
-| `nginx.conf` | Nginx config; `daemon off;` listen 12596; includes `conf.d/{alias}/upstreams.conf` (http block) + `locations.conf` (server block) per coordinator |
-| `Dockerfile` | Alpine 3.23; installs socat + nginx; `COPY . .`; `EXPOSE 12596`; HEALTHCHECK uses `wget` (BusyBox); `CMD ["sh", "robosats-client.sh"]` |
-| `docker-compose.yml` | **Dev-only** — builds `../frontend` + `../docker/tor` locally; references non-existent `../node/tor/*` path (see Traps) |
-| `docker-compose-example.yml` | **End-user reference** — has both `build: .` and `image: recksato/robosats-client:latest` (see Traps); ports published on the `tor` service |
+| `robosats-client.sh` | Starts 12 socat bridges (2 per coordinator: mainnet + testnet); generates a self-signed TLS cert (`/etc/nginx/ssl/server.crt`) if absent; then `nginx` in foreground |
+| `nginx.conf` | Nginx config; `daemon off;` HTTPS `listen 12596 ssl` (self-signed cert, `error_page 497` redirects plain HTTP to HTTPS on the same port); internal plain-HTTP healthcheck server on `127.0.0.1:8080`; includes `conf.d/{alias}/upstreams.conf` (http block) + `locations.conf` (server block) per coordinator |
+| `Dockerfile` | Alpine 3.23; installs socat + nginx + openssl; `COPY . .`; `EXPOSE 12596`; HEALTHCHECK uses `wget` (BusyBox) against `http://127.0.0.1:8080/selfhosted`; `CMD ["sh", "robosats-client.sh"]` |
+| `docker-compose.yml` | **Dev-only** — builds `../frontend` + `../docker/tor` locally; references non-existent `../node/tor/*` path (see Traps); mounts `./ssl:/etc/nginx/ssl` |
+| `docker-compose-example.yml` | **End-user reference** — has both `build: .` and `image: recksato/robosats-client:latest` (see Traps); ports published on the `tor` service; mounts `./ssl:/etc/nginx/ssl` |
 | `coordinators/` | One subdirectory per coordinator with `upstreams.conf` + `locations.conf` |
 | `basic.html` / `pro.html` | **Gitignored webpack outputs** — injected by CI; sets `window.RobosatsSettings = 'selfhosted-basic'/'selfhosted-pro'` |
 | `static/` | **Gitignored webpack output** — copied from `frontend/static` by CI before image build |
+| `ssl/` | **Gitignored** self-signed TLS certs (`server.crt`/`server.key`) — generated at container start by `robosats-client.sh`, persisted via `./ssl:/etc/nginx/ssl` volume |
 | `assets/` | App-store listing artwork (Umbrel/Start9/Citadel); **excluded from Docker image** via `.dockerignore` |
 
 Child docs (load on demand):
@@ -89,17 +92,24 @@ The CI `push`/`pull_request` path filter is `paths: ["frontend", "nodeapp"]` —
   improvement with no active blocker.
 - **`/selfhosted → 200 OK`** is the container healthcheck probe only — not used by the
   frontend to detect selfhosted mode. The frontend detects mode via `window.RobosatsSettings`.
+  It is served on the internal port `127.0.0.1:8080`, not on the public `:12596`.
 - **`/pro` ships as a first-class route.** The pro dashboard (arbitrage view) is accessible
   at `/pro` on any selfhosted deployment — same bundle, just the pro entry point.
 - **LAN/VPN access is intentional.** Port 12596 is bound to all interfaces on the tor
-  container's network, making it accessible from any device on the same LAN or VPN. There
-  is no authentication on the container itself — access control is the deployer's
-  responsibility.
+  container's network, making it accessible from any device on the same LAN or VPN. It is
+  served over **HTTPS with a self-signed cert** so browsers get a secure context
+  (`window.isSecureContext === true`, WebCrypto available — required by openpgp 6). The
+  browser will show a one-time self-signed cert warning per accepted cert. There is no
+  authentication on the container itself — access control is the deployer's responsibility.
 
 ## Traps
-- **HEALTHCHECK uses `wget`** (BusyBox, ships with Alpine) against `/selfhosted`. `curl`
-  is not installed in the image; the previous `curl --fail …` command was always failing.
-  Fixed in this codebase; do not replace `wget` with `curl` without adding a curl install.
+- **HEALTHCHECK uses `wget`** (BusyBox, ships with Alpine) against the internal plain-HTTP
+  endpoint `http://127.0.0.1:8080/selfhosted`. `curl` is not installed in the image; the
+  previous `curl --fail …` command was always failing. Do not replace `wget` with `curl`
+  without adding a curl install.
+- **Plain HTTP on `:12596` is redirected to HTTPS** via `error_page 497 =301` (same port).
+  BusyBox `wget` cannot validate self-signed certs and does not follow the redirect, so the
+  HEALTHCHECK must hit the internal `127.0.0.1:8080` listener, never the public port.
 - **Port 12596 is published by the `tor` service**, not by the `nodeapp` service. Because
   `nodeapp` uses `network_mode: service:tor`, it shares the tor container's network
   namespace. The `ports:` mapping in `docker-compose-example.yml` must be on the `tor`
@@ -140,5 +150,7 @@ The CI `push`/`pull_request` path filter is `paths: ["frontend", "nodeapp"]` —
   `nginx.conf`. See `nodeapp/coordinators/AGENTS.md` for the full procedure.
 - Do not replace `wget` in the HEALTHCHECK with `curl` — `curl` is not installed; use
   `wget -q -O-` (BusyBox, ships with Alpine) or install `curl` explicitly.
+- Keep the internal plain-HTTP healthcheck listener on `127.0.0.1:8080` — never point the
+  HEALTHCHECK back at the public HTTPS port `12596` (self-signed cert breaks `wget`).
 - Do not assume `nodeapp` sets `network_mode: bridge` — it shares the `tor` service's
   network namespace; any port mapping must live on the `tor` service.

--- a/nodeapp/Dockerfile
+++ b/nodeapp/Dockerfile
@@ -18,9 +18,10 @@ COPY ./coordinators/ /etc/nginx/conf.d/
 
 RUN apk -U --no-cache upgrade \
     && apk --no-cache add socat \
-    && apk --no-cache add nginx
+    && apk --no-cache add nginx \
+    && apk --no-cache add openssl
 
 EXPOSE 12596
-HEALTHCHECK CMD wget -q -O- http://localhost:12596/selfhosted || exit 1
+HEALTHCHECK CMD wget -q -O- http://127.0.0.1:8080/selfhosted || exit 1
 
 CMD ["sh", "robosats-client.sh"]

--- a/nodeapp/README.md
+++ b/nodeapp/README.md
@@ -11,7 +11,28 @@ The container launches two processes: 1) A set of `socat` that will expose RoboS
 # Docker compose example
 You can run the client locally with the provided example orchestration. It has both, a TOR proxy container and the robosats client.
 `docker-compose -f docker-compose-example.yml up`
-Then just visit http://localhost:12596
+Then just visit https://localhost:12596
+
+# Why does my browser show a "Not secure" warning?
+
+The client is served over HTTPS with a self-signed certificate, generated
+automatically on the first start. Browsers only show the green padlock for
+certificates issued by well-known Certificate Authorities, so a self-signed
+certificate triggers the "Not secure" warning — even though the connection is
+**really encrypted**.
+
+This is expected for self-hosted apps and is **not** a sign of a security
+problem. Click "Advanced" → "Proceed" and the app works normally. If you type
+`http://localhost:12596` you are redirected automatically to `https://`.
+
+Your traffic is encrypted from the browser to your machine, and onward to the
+RoboSats coordinators it travels through Tor.
+
+### For advanced users
+
+To get a green padlock, sign the certificate with a local Certificate Authority
+trusted by your device (e.g. `mkcert`) or import the generated certificate from
+the `./ssl/` volume into your OS/browser trust store.
 
 # Why host your own RoboSats client
 

--- a/nodeapp/docker-compose-example.yml
+++ b/nodeapp/docker-compose-example.yml
@@ -11,6 +11,8 @@ services:
       TOR_PROXY_IP: 127.0.0.1
       TOR_PROXY_PORT: 9050
     network_mode: service:tor
+    volumes:
+      - ./ssl:/etc/nginx/ssl
   tor:
     build: ../docker/tor
     container_name: tor

--- a/nodeapp/docker-compose.yml
+++ b/nodeapp/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - ./:/usr/src/robosats/
       - ./nginx.conf:/etc/nginx/nginx.conf
       - ./coordinators/:/etc/nginx/conf.d/
+      - ./ssl:/etc/nginx/ssl
 
   tor:
     build: ../docker/tor

--- a/nodeapp/nginx.conf
+++ b/nodeapp/nginx.conf
@@ -41,8 +41,15 @@ http {
 
     server {
 
-        listen 12596;
+        listen 12596 ssl;
         server_name robosats_client;
+
+        ssl_certificate     /etc/nginx/ssl/server.crt;
+        ssl_certificate_key /etc/nginx/ssl/server.key;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+
+        # Plain HTTP sent to this HTTPS port is redirected to HTTPS on the same port
+        error_page 497 =301 https://$host:12596$request_uri;
 
         # add_header Access-Control-Allow-Headers "*";
         # add_header Access-Control-Allow-Origin "*";
@@ -81,11 +88,14 @@ http {
         # Alice
         include /etc/nginx/conf.d/alice/locations.conf;
 
-        # do not log healtchecks made against "/selfhosted"
+    }
+
+    # Internal healthcheck endpoint in plain HTTP, outside the public HTTPS port
+    server {
+        listen 127.0.0.1:8080;
         location /selfhosted {
             access_log off;
             return 200 "OK";
         }
-
     }
 }

--- a/nodeapp/robosats-client.sh
+++ b/nodeapp/robosats-client.sh
@@ -70,4 +70,11 @@ mainnet_alice_socat="socat tcp4-LISTEN:${mainnet_alice_port},reuseaddr,fork,keep
 testnet_alice_socat="socat tcp4-LISTEN:${testnet_alice_port},reuseaddr,fork,keepalive,bind=127.0.0.1 SOCKS5-CONNECT:${TOR_PROXY_IP:-127.0.0.1}:${testnet_alice_onion}:80,socksport=${TOR_PROXY_PORT:-9050}"
 
 # RUN!
+mkdir -p /etc/nginx/ssl
+if [ ! -f /etc/nginx/ssl/server.crt ]; then
+    openssl req -x509 -nodes -newkey rsa:2048 -days 3650 \
+        -keyout /etc/nginx/ssl/server.key -out /etc/nginx/ssl/server.crt \
+        -subj "/CN=robosats_client" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+fi
+
 $mainnet_temple_socat & $testnet_temple_socat & $mainnet_lake_socat & $testnet_lake_socat & $mainnet_bazaar_socat & $testnet_bazaar_socat & $mainnet_freedomsats_socat & $testnet_freedomsats_socat & $mainnet_alice_socat & $testnet_alice_socat & nginx


### PR DESCRIPTION
## What does this PR do?
fix-types (PR #2639) includes the openpgp 6 bump (9b16aefd / #2630). openpgp v6 requires the WebCrypto API, which browsers only expose in a secure context (HTTPS). The self-hosted client (nodeapp) was served over plain HTTP, so on a LAN hostname it crashed at startup:
Error: The WebCrypto API is not available

## Fix
Serve the client over HTTPS on port 12596 with a self-signed cert (auto-generated on first start), restoring the secure context:
- Nginx listen 12596 ssl; plain http:// is redirected to https:// via error_page 497
- Cert persisted via ./ssl:/etc/nginx/ssl volume (gitignored); openssl added to the image
- Healthcheck moved to internal 127.0.0.1:8080 (BusyBox wget can't validate self-signed certs)
- README documents the expected "Not secure" warning + mkcert/import option for a green padlock

## Files
nodeapp/nginx.conf, Dockerfile, robosats-client.sh, both compose files, .gitignore, .dockerignore, README.md, AGENTS.md

## Test
curl -k https://localhost:12596/selfhosted → 200 · window.isSecureContext === true · app loads without the WebCrypto error

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.