### PR TITLE
ci: add dependabot groups to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     labels:
       - "dependencies"
       - "backend"
+    groups:
+      python-patch:
+        update-types: ["patch", "minor"]
+        exclude-patterns: ["django"]
+      python-major:
+        update-types: ["major"]
+        patterns: ["django"]
 
   # Frontend (frontend/package.json)
   - package-ecosystem: "npm"
@@ -19,6 +26,18 @@ updates:
     labels:
       - "dependencies"
       - "frontend"
+    groups:
+      frontend-security:
+        dependency-type: "production"
+        update-types: ["patch", "minor"]
+      frontend-eslint:
+        patterns: ["eslint*", "@eslint/*"]
+      frontend-babel-webpack:
+        patterns: ["@babel/*", "webpack*"]
+      frontend-i18n:
+        patterns: ["i18next*", "react-i18next"]
+      frontend-mui:
+        patterns: ["@mui/*", "@emotion/*"]
 
   # Electron desktop app (desktopApp/package.json)
   - package-ecosystem: "npm"
@@ -29,6 +48,9 @@ updates:
     labels:
       - "dependencies"
       - "desktop"
+    groups:
+      desktop-all:
+        patterns: ["*"]
 
   # GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -39,3 +61,10 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      ci-artifact-pipeline:
+        patterns: ["actions/upload-artifact", "dawidd6/action-download-artifact"]
+      ci-docker:
+        patterns: ["docker/*"]
+      ci-misc:
+        patterns: ["*"]


### PR DESCRIPTION
## What does this PR do?

Add grouping rules to all four dependabot entries:
- pip: python-patch (minor/patch, excl. django) + python-major (django only)
- npm /frontend: security, eslint, babel/webpack, i18n, mui groups
- npm /desktopApp: desktop-all catch-all group
- github-actions: artifact-pipeline, docker, misc groups

Prevents future 55-PR noise storms from ungrouped weekly updates. Tracked in development/dependabot-triage.md.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.