### PR TITLE
Fix  GHSA-p353-f8m7-8v95

### DIFF
--- a/frontend/src/components/Dialogs/Coordinator.tsx
+++ b/frontend/src/components/Dialogs/Coordinator.tsx
@@ -461,9 +461,7 @@ const CoordinatorDialog = ({ open = false, onClose, shortAlias }: Props): React.
               <ListItem>
                 <Alert severity={coordinator?.info?.notice_severity} sx={{ width: '100%' }}>
                   <AlertTitle>{t('Coordinator Notice')}</AlertTitle>
-                  <div
-                    dangerouslySetInnerHTML={{ __html: coordinator?.info?.notice_message ?? '' }}
-                  />
+                  <Typography variant='body2'>{coordinator?.info?.notice_message ?? ''}</Typography>
                 </Alert>
               </ListItem>
             )}


### PR DESCRIPTION
## What does this PR do?

React now renders `notice_message` as a plain text node. Any HTML or script a coordinator injects is escaped and shown literally, never parsed or executed. No sanitization library is needed because `Typography` (and React's JSX text interpolation in general) never treats child strings as HTML.
.

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.