### PR TITLE
Fix Desktop Artifact poisoning

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -36,14 +36,57 @@ jobs:
           workflow: frontend-build.yml
           workflow_conclusion: success
           name: desktop-main-static
-          path: desktopApp
+          path: ${{ runner.temp }}/desktop-main-static-artifact
 
       - name: 'Download Basic main.js Artifact for a release'
         if: inputs.semver != ''  # Only if fired as job in release.yml
         uses: actions/download-artifact@v5
         with:
           name: desktop-main-static
-          path: desktopApp
+          path: ${{ runner.temp }}/desktop-main-static-artifact
+
+      - name: 'Validate and promote artifact into desktopApp'
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/desktop-main-static-artifact
+        run: |
+          set -euo pipefail
+
+          # Artifact root must exist and contain exactly what the build produces
+          test -d "$ARTIFACT_DIR"
+          test -f "$ARTIFACT_DIR/index.html"
+          test -d "$ARTIFACT_DIR/static/frontend"
+
+          # Reject symlinks (zip-slip / path-escape vector)
+          if find "$ARTIFACT_DIR" -type l -print -quit | grep -q .; then
+            echo "::error::Artifact contains symlinks - refusing to promote"; exit 1
+          fi
+
+          # Reject non-regular, non-directory entries (devices, pipes, …)
+          if find "$ARTIFACT_DIR" ! -type d ! -type f -print -quit | grep -q .; then
+            echo "::error::Artifact contains non-regular files - refusing to promote"; exit 1
+          fi
+
+          # Reject hardlinks
+          if find "$ARTIFACT_DIR" -type f -links +1 -print -quit | grep -q .; then
+            echo "::error::Artifact contains hardlinked files - refusing to promote"; exit 1
+          fi
+
+          # Allow-list top-level entries: only index.html and static/ are expected.
+          # Anything else (index.js, package.json, tsconfig.json, tor/, assets/, dotfiles)
+          # is rejected outright to prevent overwriting committed workspace files.
+          shopt -s dotglob nullglob
+          for entry in "$ARTIFACT_DIR"/*; do
+            case "$(basename "$entry")" in
+              index.html|static) ;;
+              *) echo "::error::Unexpected entry in artifact: $(basename "$entry")"; exit 1 ;;
+            esac
+          done
+
+          # Promote only the approved paths into the workspace
+          mkdir -p desktopApp
+          rm -rf desktopApp/static
+          cp -f "$ARTIFACT_DIR/index.html" desktopApp/index.html
+          cp -R "$ARTIFACT_DIR/static"     desktopApp/static
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## What does this PR do?

1. Both artifact download steps now extract to `${{ runner.temp }}/desktop-main-static-artifact` instead of directly into `desktopApp/`.

2. A new __"Validate and promote artifact"__ step runs between the downloads and `npm install`. It:

   - Asserts `index.html` and `static/frontend/` are present (correct payload based on `frontend-build.yml:64-70` — not `main.js` as the original instructions claimed)
   - Rejects symlinks, non-regular files, and hardlinks (zip-slip/escape-hatch defences)
   - Allow-lists the top-level artifact entries to exactly `index.html` and `static/` — rejecting anything that could overwrite committed workspace files like `index.js` (Electron main process), `package.json` (drives `npm install` with `preinstall`/`postinstall`), `package-lock.json`, `tsconfig.json`, `tor/`, etc.
   - Promotes only the approved paths into `desktopApp/` via explicit `cp`

__Why the original instructions were corrected:__ The proposed guard checked for `main.js`, which does not exist in this artifact. The `desktop-main-static` artifact contains `desktopApp/static/` and `desktopApp/index.html` (webpack outputs). Guarding for `main.js` would have made the step always fail, breaking the build, while also not protecting the actual high-value targets (`index.js`/`package.json`).


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.