### PR TITLE
Server-side request forgery

### DIFF
--- a/android/app/src/main/java/com/robosats/WebAppInterface.kt
+++ b/android/app/src/main/java/com/robosats/WebAppInterface.kt
@@ -151,6 +151,11 @@ class WebAppInterface(private val context: MainActivity, private val webView: We
             Log.e(TAG, "Invalid UUID for getTorStatus: $uuid")
             return
         }
+        if (!isValidUrl(path)) {
+            Log.e(TAG, "Invalid or disallowed URL for openWS: $path")
+            rejectPromise(uuid, "Invalid URL")
+            return
+        }
 
         try {
             Log.d(TAG, "WebSocket opening: $path")
@@ -381,6 +386,11 @@ class WebAppInterface(private val context: MainActivity, private val webView: We
         if (!isValidUuid(uuid)) {
             Log.e(TAG, "Invalid UUID for sendRequest: $uuid")
             rejectPromise(uuid, "Invalid UUID")
+            return
+        }
+        if (!isValidUrl(url)) {
+            Log.e(TAG, "Invalid or disallowed URL for sendRequest: $url")
+            rejectPromise(uuid, "Invalid URL")
             return
         }
 


### PR DESCRIPTION
## What does this PR do?

The `sendRequest` function at line 378 accepted a user-controlled `url` parameter and used it directly in an OkHttp request without any URL validation — unlike `sendBinary` (line 247) and `getBinary` (line 329), both of which already called `isValidUrl(url)` before proceeding.

The fix adds the missing guard to `sendRequest`, exactly matching the pattern used by the other two HTTP methods:

```kotlin
if (!isValidUrl(url)) {
    Log.e(TAG, "Invalid or disallowed URL for sendRequest: $url")
    rejectPromise(uuid, "Invalid URL")
    return
}
```

The existing `isValidUrl` function is a solid SSRF defence: it enforces `http/https/ws/wss` schemes only, and explicitly blocks `localhost`, the full `127.x.x.x` loopback range, RFC-1918 private ranges (`10.x`, `172.16–31.x`, `192.168.x`), link-local (`169.254.x`), and IPv6 loopback (`::1`). `.onion` addresses are correctly left unrestricted since all coordinator traffic runs through the Tor SOCKS proxy.


## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.