### PR TITLE
Fix CR in auth header

### DIFF
--- a/frontend/src/models/Robot.model.ts
+++ b/frontend/src/models/Robot.model.ts
@@ -79,8 +79,8 @@ class Robot {
       tokenSHA256,
       nostrPubkey,
       keys: {
-        pubKey: pubKey.split('\n').join('\\'),
-        encPrivKey: encPrivKey.split('\n').join('\\'),
+        pubKey: pubKey.replace(/[\r\n]+/g, '\\'),
+        encPrivKey: encPrivKey.replace(/[\r\n]+/g, '\\'),
       },
     };
   };


### PR DESCRIPTION
## What does this PR do?

Normalize Windows CRLF line endings out of the serialized PGP public/private key segments in the robot Authorization header. Raw carriage-return characters produce an HTTP-invalid header value, causing window.fetch to throw TypeError: invalid header value on every authenticated request (web, desktop, and Android). Switching from split('\n').join('\\') to replace(/[\r\n]+/g, '\\') strips both CR and LF before they ever reach the header, while preserving the backslash-separated key contract expected by the coordinator (api/utils.py).

## Checklist before merging
- [ ] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.