### PR TITLE
fix(frontend): keep PGP armor blank line when escaping robot key headers

### DIFF
--- a/frontend/src/models/Robot.model.ts
+++ b/frontend/src/models/Robot.model.ts
@@ -79,8 +79,8 @@ class Robot {
       tokenSHA256,
       nostrPubkey,
       keys: {
-        pubKey: pubKey.replace(/[\r\n]+/g, '\\'),
-        encPrivKey: encPrivKey.replace(/[\r\n]+/g, '\\'),
+        pubKey: pubKey.replace(/\r\n?/g, '\n').split('\n').join('\\'),
+        encPrivKey: encPrivKey.replace(/\r\n?/g, '\n').split('\n').join('\\'),
       },
     };
   };


### PR DESCRIPTION
## Problem

Buyers whose robot was created recently sometimes cannot lock their payout invoice:
the app keeps showing "loading" and no request is sent. For those robots, OpenPGP.js
refuses to read the stored private key:
`Mandatory blank line missing between armor headers and armor data`.

## Root cause

On first login the client sends the robot's PGP keys in the `Authorization` header
with newlines escaped as backslashes; the coordinator converts each `\` back to a
newline and stores the result.

`getAuthHeaders()` currently escapes with `replace(/[\r\n]+/g, '\\')`. The `+`
quantifier collapses **consecutive** newlines into a **single** backslash. PGP armor
has a mandatory blank line right after the `-----BEGIN PGP ... KEY BLOCK-----` line
(two newlines), so that blank line is lost before the key ever reaches the
coordinator, and the stored armor is malformed forever.

## Fix

Escape in two steps (frontend/src/models/Robot.model.ts, 2 lines):

1. `replace(/\r\n?/g, '\n')` — normalize CRLF / lone CR to LF, so no carriage return
   ever ends up in the header value (this keeps the CRLF fix from the previous PR,
   which was correct: raw `\r` makes the header invalid and `window.fetch` throws
   `TypeError: invalid header value`).
2. `split('\n').join('\\')` — escape **each** newline to one backslash, so the armor
   blank line survives and the coordinator's `\` → newline decode restores the key
   byte-for-byte.

## Why not a revert

The previous change was correct in intent (strip CR from the header); a plain revert
to `split('\n').join('\\')` would leave `\r` in the header for CRLF keys and re-break
Windows clients. This keeps that behavior while restoring the lost blank line.

## Impact / testing

- One file, two lines, frontend only. No API or backend changes.
- Verified round-trip for LF and CRLF armored keys: escaped header contains no CR,
  blank line is two backslashes, and applying the coordinator's decode
  (`\` → newline) reproduces the original key exactly.
- No effect on already-stored keys: robots whose stored armor is already missing the
  blank line need a coordinator-side data fix (separate follow-up).
