### PR TITLE
fix: show swap orders from search dialog

### DIFF
--- a/frontend/src/components/Dialogs/Search.tsx
+++ b/frontend/src/components/Dialogs/Search.tsx
@@ -128,7 +128,7 @@ const SearchDialog = ({ open = false, onClose }: Props): React.JSX.Element => {
                         <Button
                           color='primary'
                           onClick={() => {
-                            setFav({ ...fav, mode: 'swap', type: 1 });
+                            setFav({ ...fav, mode: 'swap', type: 1, currency: 1000 });
                             setStep('3');
                           }}
                         >
@@ -138,7 +138,7 @@ const SearchDialog = ({ open = false, onClose }: Props): React.JSX.Element => {
                         <Button
                           color='secondary'
                           onClick={() => {
-                            setFav({ ...fav, mode: 'swap', type: 0 });
+                            setFav({ ...fav, mode: 'swap', type: 0, currency: 1000 });
                             setStep('3');
                           }}
                         >


### PR DESCRIPTION
Replaces #2706, which GitHub closed automatically when its head fork was accidentally deleted. This branch restores the exact reviewed commit.

## What does this PR do?
Fixes #2449

This PR resets the favorite currency to the Lightning swap pseudo-currency (`1000`) when either swap direction is selected in the search dialog. The subsequent order-book filter therefore receives swap mode and swap currency together instead of retaining the previous fiat currency and showing regular sell orders.

### Validation

- `pre-commit run --files frontend/src/components/Dialogs/Search.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.

