### PR TITLE
Fix image upload errors not shown in chat

### DIFF
--- a/frontend/src/components/TradeBox/EncryptedChat/index.tsx
+++ b/frontend/src/components/TradeBox/EncryptedChat/index.tsx
@@ -270,15 +270,16 @@ const EncryptedChat: React.FC<Props> = ({
 
   const sendFile = async (file: File): Promise<void> => {
     if (!blossomEnabled) {
-      setError('This coordinator does not offer image uploads');
-      return;
+      throw new Error('This coordinator does not offer image uploads');
     }
     const slot = garage.getSlot();
     const coordinator = federation.getCoordinator(order.shortAlias);
     const peerPublicKey = order.is_maker ? order.taker_nostr_pubkey : order.maker_nostr_pubkey;
     const ownPublicKey = order.is_maker ? order.maker_nostr_pubkey : order.taker_nostr_pubkey;
 
-    if (!slot?.nostrSecKey || !peerPublicKey || !ownPublicKey || !coordinator) return;
+    if (!slot?.nostrSecKey || !peerPublicKey || !ownPublicKey || !coordinator) {
+      throw new Error(t('Cannot send file: missing keys or peer not connected'));
+    }
 
     // Preflight: verify canvas readback is allowed before stripping EXIF.
     // Tor Browser (and hardened browsers) block canvas extraction behind a
@@ -287,12 +288,11 @@ const EncryptedChat: React.FC<Props> = ({
     // Abort and show a clear error so the user can grant the permission first.
     const canvasOk = await isCanvasReadbackAllowed();
     if (!canvasOk) {
-      setError(
+      throw new Error(
         t(
           'Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.',
         ),
       );
-      return;
     }
 
     try {
@@ -339,7 +339,7 @@ const EncryptedChat: React.FC<Props> = ({
       await sendToCoordinator(imageMetadata);
     } catch (error) {
       console.error('File upload error:', error);
-      setError(error instanceof Error ? error.message : 'File upload failed');
+      throw error instanceof Error ? error : new Error('File upload failed');
     }
   };
 

--- a/frontend/static/locales/ca.json
+++ b/frontend/static/locales/ca.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...esperant",

--- a/frontend/static/locales/cs.json
+++ b/frontend/static/locales/cs.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...čekání",

--- a/frontend/static/locales/de.json
+++ b/frontend/static/locales/de.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...warten",

--- a/frontend/static/locales/en.json
+++ b/frontend/static/locales/en.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...waiting",

--- a/frontend/static/locales/es.json
+++ b/frontend/static/locales/es.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...esperando",

--- a/frontend/static/locales/eu.json
+++ b/frontend/static/locales/eu.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...zain",

--- a/frontend/static/locales/fr.json
+++ b/frontend/static/locales/fr.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...attente",

--- a/frontend/static/locales/it.json
+++ b/frontend/static/locales/it.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...in attesa",

--- a/frontend/static/locales/ja.json
+++ b/frontend/static/locales/ja.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...待機中",

--- a/frontend/static/locales/pl.json
+++ b/frontend/static/locales/pl.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...czekanie",

--- a/frontend/static/locales/pt.json
+++ b/frontend/static/locales/pt.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...esperando",

--- a/frontend/static/locales/ru.json
+++ b/frontend/static/locales/ru.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...ожидание",

--- a/frontend/static/locales/sv.json
+++ b/frontend/static/locales/sv.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...väntar",

--- a/frontend/static/locales/sw.json
+++ b/frontend/static/locales/sw.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...inasubiri",

--- a/frontend/static/locales/th.json
+++ b/frontend/static/locales/th.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...รอ",

--- a/frontend/static/locales/zh-SI.json
+++ b/frontend/static/locales/zh-SI.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...正在等待",

--- a/frontend/static/locales/zh-TR.json
+++ b/frontend/static/locales/zh-TR.json
@@ -617,6 +617,7 @@
   "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.": "Images are end-to-end encrypted, but they retain their original metadata (like GPS location). The recipient will be able to see this information. Please remove any sensitive data before uploading.",
   "Sensitive Data": "Sensitive Data",
   "#64": "Phrases in components/TradeBox/EncryptedChat/index.tsx",
+  "Cannot send file: missing keys or peer not connected": "Cannot send file: missing keys or peer not connected",
   "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.": "Canvas access is blocked. In Tor Browser, click the canvas icon in the address bar and allow canvas extraction, then try again.",
   "#65": "Phrases in components/TradeBox/EncryptedChat/ChatHeader/index.tsx",
   "...waiting": "...正在等待",


### PR DESCRIPTION
## What does this PR do?

EncryptedChat's sendFile swallowed validation and upload failures (canvas-readback blocked, blossom disabled, missing keys, upload errors) by setting the container-level error state and returning silently. That state is only passed to EncryptedApiChat, so in the primary EncryptedSocketChat mode no error surfaced — the Tor Browser canvas-permission failure looked like a no-op. The fix makes sendFile throw on every failure path, which the existing .catch() handlers in both EncryptedApiChat and EncryptedSocketChat already convert into the visible <Typography color="error"> message.


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.