### PR TITLE
Eleuteria testnet4

### DIFF
--- a/api/federation.json
+++ b/api/federation.json
@@ -211,11 +211,11 @@
     "nostrHexPubkey": "0f243ba69b7c7ffa73934bc7f5fa6586b8013afdc310d808b1ec2c2c98f1c219",
     "contact": {
       "email": "backsocks@proton.me",
-      "telegram": "@asyscom",
+      "telegram": "@eleuteriacoordinator",
       "simplex": "https://smp17.simplex.im/a#w2lbfI-Rbea5dukWc38CVDQEzLryz8q7p2C4NGEViNg",
       "pgp": "/static/federation/pgp/546143E7584783759F6829AF6DA5626C8AF8DF61.asc",
       "nostr": "npub1pujrhf5m03ll5uunf0rlt7n9s6uqzwhacvgdsz93askzex83cgvsukm9hf",
-      "website": null,
+      "website": "https://eleuteria-robosat.github.io/",
       "matrix": null,
       "fingerprint": "546143E7584783759F6829AF6DA5626C8AF8DF61"
     },
@@ -239,14 +239,16 @@
       "i2p": null
     },
     "testnet": {
-      "onion": null,
+      "onion": "http://kfpwwlt2x6kzeor7gbrwjeokdztlkqzyhc4grg7zkeko4bh5b6s24oid.onion",
       "clearnet": null,
       "i2p": null
     },
     "mainnetNodesPubkeys": [
       "03808d86fee8345c7b470f792f62e3a3cba78ad49d75d4623c8e27520c34f90d5b"
     ],
-    "testnetNodesPubkeys": [],
+    "testnetNodesPubkeys": [
+      "03beb591288aa9266364493a0e820ffce39b37b0a555871824609e7fe38efc2b1e"
+    ],
     "federated": true
   },
   "freeport": {

--- a/frontend/static/federation.json
+++ b/frontend/static/federation.json
@@ -211,11 +211,11 @@
     "nostrHexPubkey": "0f243ba69b7c7ffa73934bc7f5fa6586b8013afdc310d808b1ec2c2c98f1c219",
     "contact": {
       "email": "backsocks@proton.me",
-      "telegram": "@asyscom",
+      "telegram": "@eleuteriacoordinator",
       "simplex": "https://smp17.simplex.im/a#w2lbfI-Rbea5dukWc38CVDQEzLryz8q7p2C4NGEViNg",
       "pgp": "/static/federation/pgp/546143E7584783759F6829AF6DA5626C8AF8DF61.asc",
       "nostr": "npub1pujrhf5m03ll5uunf0rlt7n9s6uqzwhacvgdsz93askzex83cgvsukm9hf",
-      "website": null,
+      "website": "https://eleuteria-robosat.github.io",
       "matrix": null,
       "fingerprint": "546143E7584783759F6829AF6DA5626C8AF8DF61"
     },
@@ -239,7 +239,7 @@
       "i2p": null
     },
     "testnet": {
-      "onion": null,
+      "onion": http://kfpwwlt2x6kzeor7gbrwjeokdztlkqzyhc4grg7zkeko4bh5b6s24oid.onion,
       "clearnet": null,
       "i2p": null
     },

--- a/frontend/static/federation.json
+++ b/frontend/static/federation.json
@@ -239,14 +239,16 @@
       "i2p": null
     },
     "testnet": {
-      "onion": http://kfpwwlt2x6kzeor7gbrwjeokdztlkqzyhc4grg7zkeko4bh5b6s24oid.onion,
+      "onion": "http://kfpwwlt2x6kzeor7gbrwjeokdztlkqzyhc4grg7zkeko4bh5b6s24oid.onion",
       "clearnet": null,
       "i2p": null
     },
     "mainnetNodesPubkeys": [
       "03808d86fee8345c7b470f792f62e3a3cba78ad49d75d4623c8e27520c34f90d5b"
     ],
-    "testnetNodesPubkeys": [],
+    "testnetNodesPubkeys": [
+      "03beb591288aa9266364493a0e820ffce39b37b0a555871824609e7fe38efc2b1e"
+    ],
     "federated": true
   },
   "freeport": {


### PR DESCRIPTION
## What does this PR do?

Updates Eleuteria coordinator information in both copies of `federation.json`.

- Adds the Eleuteria Testnet4 onion endpoint.
- Adds the Eleuteria Testnet4 Lightning node pubkey.
- Updates the Telegram contact to `@eleuteriacoordinator`.
- Adds the new Eleuteria website.

These changes enable Eleuteria to be used for Testnet4 testing of the full RoboSats order and dispute flows.