### PR TITLE
fix: unify federation order URLs

### DIFF
--- a/api/AGENTS.md
+++ b/api/AGENTS.md
@@ -130,12 +130,23 @@ Traps for a dispatch bug). Message types: `welcome`, `order_published`,
 throttles on `CHAT_NOTIFICATION_TIMEGAP` min (env, default 5) since the prior chatroom
 message — except the first message, which always notifies. Webhooks restricted to
 `.onion` via `Robot.is_valid_onion_url` (`@staticmethod`, not a model constraint).
+Telegram descriptions embed `Notifications.order_url(order)` —
+`http://{HOST_NAME}/order/{shortAlias}/{order.id}` where `shortAlias` comes from
+`get_federation_short_alias()` (`api/utils.py`): `COORDINATOR_ALIAS` (normalized:
+lowercased, spaces stripped) matched against each federation entry's key, `identifier`
+and `longAlias` → entry `shortAlias`. Document loading mirrors `_load_federation_doc`
+(`views.py`): `FEDERATION_JSON_PATH` if set, bundled `api/federation.json` as fallback,
+raw-alias fallback if nothing resolves.
+Never emit `COORDINATOR_ALIAS` raw in order URLs/tags — it can diverge from the
+federation `shortAlias` (e.g. `templeofsats` vs `temple`) and the frontend cannot route it.
 
 ## Nostr (`nostr.py`)
 Order events (kind 38383), NIP-69 tags: `d, name, k, f, s, amt, fa, pm, premium, source,
 expiration, y, network, layer, bond, z` (+`g` only if lat/long set). `get_status_tag` is
 binary: `"pending"` only if `status==PUB`, else `"success"`. No order-id tag on the order
 event — `d` is `md5(COORDINATOR_ALIAS+order.id)` as UUID (DM event does carry `order_id`).
+The DM `order_id` tag and the `source` tag use `get_federation_short_alias()` (see
+Notifications above); `d` and `y` keep raw `COORDINATOR_ALIAS`.
 Password orders (`order.password is not None`) skipped before construction (see Product
 intent). DMs via `send_private_msg`; signs with `NOSTR_NSEC`; publishes to one self-hosted
 strfry relay (`STRFRY_HOST`/`STRFRY_PORT`) over plain `ws://`.

--- a/api/nostr.py
+++ b/api/nostr.py
@@ -15,6 +15,7 @@ from nostr_sdk import (
     nip17_make_private_msg_async,
 )
 from api.models import Order
+from api.utils import get_federation_short_alias
 from decouple import config
 
 
@@ -65,7 +66,7 @@ class Nostr:
             Tag.parse(
                 [
                     "order_id",
-                    f"{config('COORDINATOR_ALIAS', cast=str).lower()}/{order.id}",
+                    f"{get_federation_short_alias()}/{order.id}",
                 ]
             ),
             Tag.parse(["status", str(order.status)]),
@@ -130,7 +131,7 @@ class Nostr:
             Tag.parse(
                 [
                     "source",
-                    f"http://{config('HOST_NAME')}/order/{config('COORDINATOR_ALIAS', cast=str).lower()}/{order.id}",
+                    f"http://{config('HOST_NAME')}/order/{get_federation_short_alias()}/{order.id}",
                 ]
             ),
             Tag.parse(

--- a/api/notifications.py
+++ b/api/notifications.py
@@ -9,7 +9,7 @@ from api.models import (
     Order,
     Notification,
 )
-from api.utils import get_session
+from api.utils import get_federation_short_alias, get_session
 from api.tasks import nostr_send_notification_event
 
 logger = logging.getLogger("api.notifications")
@@ -40,6 +40,10 @@ class Notifications:
         context["webhook_url"] = user.robot.webhook_url or ""
 
         return context
+
+    def order_url(self, order):
+        """Builds the frontend order URL with the federation shortAlias route segment"""
+        return f"http://{self.site}/order/{get_federation_short_alias()}/{order.id}"
 
     def send_message(
         self, order, robot, title, description="", event_type="notification"
@@ -190,12 +194,10 @@ class Notifications:
         lang = order.maker.robot.telegram_lang_code
         if lang == "es":
             title = f"✅ Hey {order.maker.username} ¡Tu orden con ID {order.id} ha sido tomada por {order.taker.username}!🥳"
-            description = f"Visita http://{self.site}/order/{order.id} para continuar."
+            description = f"Visita {self.order_url(order)} para continuar."
         else:
             title = f"✅ Hey {order.maker.username}, your order was taken by {order.taker.username}!🥳"
-            description = (
-                f"Visit http://{self.site}/order/{order.id} to proceed with the trade."
-            )
+            description = f"Visit {self.order_url(order)} to proceed with the trade."
         self.send_message(order, order.maker.robot, title, description)
 
         lang = order.taker.robot.telegram_lang_code
@@ -212,10 +214,14 @@ class Notifications:
             lang = user.robot.telegram_lang_code
             if lang == "es":
                 title = f"✅ Hey {user.username}, el depósito de garantía y el recibo del comprador han sido recibidos. Es hora de enviar el dinero fiat."
-                description = f"Visita http://{self.site}/order/{order.id} para hablar con tu contraparte."
+                description = (
+                    f"Visita {self.order_url(order)} para hablar con tu contraparte."
+                )
             else:
                 title = f"✅ Hey {user.username}, the escrow and invoice have been submitted. The fiat exchange starts now via the platform chat."
-                description = f"Visit http://{self.site}/order/{order.id} to talk with your counterpart."
+                description = (
+                    f"Visit {self.order_url(order)} to talk with your counterpart."
+                )
             self.send_message(order, user.robot, title, description)
         return
 
@@ -223,10 +229,10 @@ class Notifications:
         lang = order.maker.robot.telegram_lang_code
         if lang == "es":
             title = f"😪 Hey {order.maker.username}, tu orden con ID {order.id} ha expirado sin ser tomada por ningún robot."
-            description = f"Visita http://{self.site}/order/{order.id} para renovarla."
+            description = f"Visita {self.order_url(order)} para renovarla."
         else:
             title = f"😪 Hey {order.maker.username}, your order with ID {order.id} has expired without a taker."
-            description = f"Visit http://{self.site}/order/{order.id} to renew it."
+            description = f"Visit {self.order_url(order)} to renew it."
         self.send_message(order, order.maker.robot, title, description)
         return
 

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -1,0 +1,74 @@
+"""
+Unit tests for api/notifications.py — order URL formation for Telegram descriptions.
+
+Coverage:
+- order_url: /order/{shortAlias}/{orderId} shape with the federation-resolved alias
+- order_taken_confirmed, fiat_exchange_starts, order_expired_untaken: descriptions
+  embed the full order URL (regression: URLs used to omit the alias and 404 on the
+  Django route /order/<shortAlias>/<int:orderId>/)
+
+Message fan-out (Telegram HTTP, Nostr, webhook) is not exercised here.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from api.notifications import Notifications
+
+
+def _make_order(order_id=42):
+    order = MagicMock()
+    order.id = order_id
+    order.maker = MagicMock()
+    order.taker = MagicMock()
+    return order
+
+
+@patch.object(Notifications, "site", "test.onion")
+class TestOrderUrl(TestCase):
+    """Unit-test Notifications.order_url and its embedding in descriptions."""
+
+    def setUp(self):
+        self.notifications = Notifications()
+
+    @patch("api.notifications.get_federation_short_alias")
+    def test_order_url_contains_short_alias_and_order_id(self, mock_alias):
+        mock_alias.return_value = "temple"
+        url = self.notifications.order_url(_make_order(order_id=42))
+        self.assertEqual(url, "http://test.onion/order/temple/42")
+
+    @patch("api.notifications.get_federation_short_alias")
+    def test_order_url_never_omits_the_alias_segment(self, mock_alias):
+        mock_alias.return_value = "lake"
+        url = self.notifications.order_url(_make_order(order_id=7))
+        self.assertRegex(url, r"^http://test\.onion/order/lake/7$")
+
+    @patch("api.notifications.Notifications.send_message")
+    @patch("api.notifications.get_federation_short_alias")
+    def test_order_taken_confirmed_maker_description_embeds_url(
+        self, mock_alias, mock_send
+    ):
+        mock_alias.return_value = "temple"
+        order = _make_order(order_id=99)
+        self.notifications.order_taken_confirmed(order)
+        maker_description = mock_send.call_args_list[0].args[3]
+        self.assertIn("http://test.onion/order/temple/99", maker_description)
+
+    @patch("api.notifications.Notifications.send_message")
+    @patch("api.notifications.get_federation_short_alias")
+    def test_fiat_exchange_starts_descriptions_embed_url(self, mock_alias, mock_send):
+        mock_alias.return_value = "lake"
+        order = _make_order(order_id=5)
+        self.notifications.fiat_exchange_starts(order)
+        for call in mock_send.call_args_list:
+            self.assertIn("http://test.onion/order/lake/5", call.args[3])
+
+    @patch("api.notifications.Notifications.send_message")
+    @patch("api.notifications.get_federation_short_alias")
+    def test_order_expired_untaken_description_embeds_url(self, mock_alias, mock_send):
+        mock_alias.return_value = "bazaar"
+        order = _make_order(order_id=123)
+        self.notifications.order_expired_untaken(order)
+        description = mock_send.call_args_list[0].args[3]
+        self.assertIn("http://test.onion/order/bazaar/123", description)

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,3 +1,5 @@
+import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -16,6 +18,7 @@ from api.utils import (
     bitcoind_rpc,
     get_cln_version,
     get_exchange_rates,
+    get_federation_short_alias,
     get_lnd_version,
     get_robosats_commit,
     get_session,
@@ -265,9 +268,12 @@ class TestUtils(TestCase):
 
         for key in malformed_keys:
             with self.subTest(key=key):
-                is_valid, error, returned_pub_key, returned_enc_priv_key = (
-                    validate_pgp_keys(key, enc_priv_key)
-                )
+                (
+                    is_valid,
+                    error,
+                    returned_pub_key,
+                    returned_enc_priv_key,
+                ) = validate_pgp_keys(key, enc_priv_key)
                 self.assertFalse(is_valid)
                 self.assertEqual(error["error_code"], 1034)
                 self.assertIsNone(returned_pub_key)
@@ -423,3 +429,119 @@ class TestUtils(TestCase):
         self.assertEqual(
             linked_logs, '<b><a href="/coordinator/api/robot/1">robot_name</a></b>'
         )
+
+
+class TestGetFederationShortAlias(TestCase):
+    """Unit-test the COORDINATOR_ALIAS → federation shortAlias resolver."""
+
+    def setUp(self):
+        get_federation_short_alias.cache_clear()
+        self._tmp_paths = []
+
+    def tearDown(self):
+        get_federation_short_alias.cache_clear()
+        for path in self._tmp_paths:
+            os.unlink(path)
+
+    def _write_doc(self, doc):
+        tmp = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+        json.dump(doc, tmp)
+        tmp.close()
+        self._tmp_paths.append(tmp.name)
+        return tmp.name
+
+    def _patch_config(self, mock_config, coordinator_alias, federation_path):
+        mock_config.side_effect = lambda key, **kw: {
+            "COORDINATOR_ALIAS": coordinator_alias,
+            "FEDERATION_JSON_PATH": federation_path,
+        }.get(key, kw.get("default", ""))
+
+    @patch("api.utils.config")
+    def test_key_match_returns_key(self, mock_config):
+        path = self._write_doc(
+            {"temple": {"shortAlias": "temple", "identifier": "templeofsats"}}
+        )
+        self._patch_config(mock_config, "temple", path)
+        self.assertEqual(get_federation_short_alias(), "temple")
+
+    @patch("api.utils.config")
+    def test_identifier_match_returns_short_alias(self, mock_config):
+        path = self._write_doc(
+            {"lake": {"shortAlias": "lake", "identifier": "thebiglake"}}
+        )
+        self._patch_config(mock_config, "TheBigLake", path)
+        self.assertEqual(get_federation_short_alias(), "lake")
+
+    @patch("api.utils.config")
+    def test_identifier_match_is_case_insensitive(self, mock_config):
+        path = self._write_doc(
+            {"temple": {"shortAlias": "temple", "identifier": "templeofsats"}}
+        )
+        self._patch_config(mock_config, "TempleOfSats", path)
+        self.assertEqual(get_federation_short_alias(), "temple")
+
+    @patch("api.utils.config")
+    def test_long_alias_match_ignores_spaces_and_case(self, mock_config):
+        path = self._write_doc(
+            {
+                "temple": {
+                    "shortAlias": "temple",
+                    "longAlias": "Temple of Sats",
+                    "identifier": "templeofsats",
+                }
+            }
+        )
+        self._patch_config(mock_config, "Temple Of Sats", path)
+        self.assertEqual(get_federation_short_alias(), "temple")
+
+    @patch("api.utils.config")
+    def test_long_alias_match_when_identifier_diverges(self, mock_config):
+        path = self._write_doc(
+            {
+                "bazaar": {
+                    "shortAlias": "bazaar",
+                    "longAlias": "LibreBazaar",
+                    "identifier": "bazaar",
+                }
+            }
+        )
+        self._patch_config(mock_config, "LibreBazaar", path)
+        self.assertEqual(get_federation_short_alias(), "bazaar")
+
+    @patch("api.utils._FEDERATION_BUNDLED_PATH", "/nonexistent/bundled.json")
+    @patch("api.utils.config")
+    def test_no_match_falls_back_to_raw_alias(self, mock_config):
+        path = self._write_doc(
+            {"bazaar": {"shortAlias": "bazaar", "identifier": "bazaar"}}
+        )
+        self._patch_config(mock_config, "unknowncoord", path)
+        self.assertEqual(get_federation_short_alias(), "unknowncoord")
+
+    @patch("api.utils.config")
+    def test_unset_federation_path_uses_bundled(self, mock_config):
+        bundled = self._write_doc(
+            {"lake": {"shortAlias": "lake", "identifier": "thebiglake"}}
+        )
+        self._patch_config(mock_config, "TheBigLake", "")
+        with patch("api.utils._FEDERATION_BUNDLED_PATH", bundled):
+            self.assertEqual(get_federation_short_alias(), "lake")
+
+    @patch("api.utils.config")
+    def test_invalid_custom_path_falls_back_to_bundled(self, mock_config):
+        bundled = self._write_doc(
+            {"lake": {"shortAlias": "lake", "identifier": "thebiglake"}}
+        )
+        self._patch_config(mock_config, "TheBigLake", "/nonexistent/custom.json")
+        with patch("api.utils._FEDERATION_BUNDLED_PATH", bundled):
+            self.assertEqual(get_federation_short_alias(), "lake")
+
+    @patch("api.utils._FEDERATION_BUNDLED_PATH", "/nonexistent/bundled.json")
+    @patch("api.utils.config")
+    def test_both_paths_invalid_falls_back_to_raw_alias(self, mock_config):
+        self._patch_config(mock_config, "somecoord", "/nonexistent/custom.json")
+        self.assertEqual(get_federation_short_alias(), "somecoord")
+
+    @patch("api.utils.config")
+    def test_empty_alias_returns_empty(self, mock_config):
+        self._patch_config(mock_config, "", "")
+        self.assertEqual(get_federation_short_alias(), "")

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,7 @@
+import functools
 import json
 import logging
+import os
 import re
 from datetime import datetime, timedelta
 from datetime import timezone as datetime_timezone
@@ -31,6 +33,49 @@ def get_session():
             "https": "socks5h://" + TOR_PROXY,
         }
     return session
+
+
+_FEDERATION_BUNDLED_PATH = os.path.join(os.path.dirname(__file__), "federation.json")
+
+
+def _federation_doc_paths() -> list[str]:
+    """Custom FEDERATION_JSON_PATH first, bundled copy as fallback — mirrors _load_federation_doc."""
+    paths = [config("FEDERATION_JSON_PATH", default="", cast=str).strip()]
+    paths.append(_FEDERATION_BUNDLED_PATH)
+    return [p for p in paths if p]
+
+
+@functools.lru_cache(maxsize=1)
+def get_federation_short_alias() -> str:
+    """
+    Resolves this coordinator's federation routing `shortAlias` from its
+    COORDINATOR_ALIAS env identity, which may differ from the `shortAlias`
+    used in /order/<shortAlias>/<orderId>/ URLs (e.g. 'LibreBazaar' → 'bazaar').
+    Matches (lowercased, space-stripped) against each entry's key,
+    `identifier` and `longAlias` in the federation document.
+    """
+    alias = config("COORDINATOR_ALIAS", cast=str, default="").lower().replace(" ", "")
+    if not alias:
+        return alias
+
+    for path in _federation_doc_paths():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                doc = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning(f"Could not load federation document '{path}': {e}")
+            continue
+
+        for key, entry in doc.items():
+            candidates = (
+                key,
+                str(entry.get("identifier", "")),
+                str(entry.get("longAlias", "")),
+            )
+            if alias in (c.lower().replace(" ", "") for c in candidates):
+                return key
+
+    return alias
 
 
 def bitcoind_rpc(method, params=None):

--- a/frontend/src/basic/TopBar/NotificationsDrawer/NotificationCard/index.tsx
+++ b/frontend/src/basic/TopBar/NotificationsDrawer/NotificationCard/index.tsx
@@ -49,14 +49,15 @@ const NotificationCard: React.FC<Props> = ({ event, robotHashId, coordinator, se
   }, [coordinator]);
 
   const handleOnClick = () => {
-    const orderId = event.tags.find((t) => t[0] === 'order_id')?.[1];
-    if (orderId) {
+    const orderTag = event.tags.find((t) => t[0] === 'order_id')?.[1] ?? '';
+    const orderId = orderTag.split('/').pop();
+    if (orderId && coordinator) {
       const nostrHexPubkey = event.tags.find((t) => t[0] === 'p')?.[1];
       const slot = garage.getSlotByNostrPubKey(nostrHexPubkey ?? '');
       if (slot?.token) {
         setShow(false);
         garage.setCurrentSlot(slot.token);
-        navigateToPage(`order/${orderId}`, navigate);
+        navigateToPage(`order/${coordinator.shortAlias}/${orderId}`, navigate);
       }
     }
   };

--- a/frontend/src/basic/TopBar/NotificationsDrawer/index.tsx
+++ b/frontend/src/basic/TopBar/NotificationsDrawer/index.tsx
@@ -118,14 +118,18 @@ const NotificationsDrawer = ({ show, setShow }: NotificationsDrawerProps): React
   };
 
   const handleOnClickSnak = () => {
-    const orderId = snakEvent?.tags.find((t) => t[0] === 'order_id')?.[1];
-    if (orderId) {
+    const orderTag = snakEvent?.tags.find((t) => t[0] === 'order_id')?.[1] ?? '';
+    const orderId = orderTag.split('/').pop();
+    if (orderId && snakEvent) {
+      const coordinator = federation
+        .getCoordinators()
+        .find((c) => c.nostrHexPubkey === snakEvent?.pubkey);
       const nostrHexPubkey = snakEvent.tags.find((t) => t[0] === 'p')?.[1];
       const slot = garage.getSlotByNostrPubKey(nostrHexPubkey ?? '');
-      if (slot?.token) {
+      if (coordinator && slot?.token) {
         setShow(false);
         garage.setCurrentSlot(slot.token);
-        navigateToPage(`order/${orderId}`, navigate);
+        navigateToPage(`order/${coordinator.shortAlias}/${orderId}`, navigate);
       }
     }
   };

--- a/frontend/static/AGENTS.md
+++ b/frontend/static/AGENTS.md
@@ -58,6 +58,8 @@ Also contains Python locale tooling:
 
 `federation.json` is the canonical, **maintainer-owned** coordinator seed list. Changes require a webpack rebuild to propagate into the bundle. It is imported at module load time in multiple places. `lnproxies.json` and `thirdparties.json` follow the same pattern — not user-configurable at runtime, propagated only via build.
 
+**`shortAlias` vs `identifier`.** `shortAlias` is the cross-layer **routing key** — it keys the federation map, drives the frontend route `/order/<shortAlias>/<orderId>/`, and must match `nodeapp/coordinators/{alias}/`. `identifier` is the coordinator's canonical deployment alias (`COORDINATOR_ALIAS` env, e.g. `templeofsats` for `temple`, `thebiglake` for `lake`); it is **not** used by the frontend (`Coordinator.model.ts` never loads it). The backend resolver `get_federation_short_alias()` (`api/utils.py`) matches `COORDINATOR_ALIAS` against the entry `key`, `identifier` and `longAlias` (normalized) to emit the `shortAlias` in Telegram order URLs and Nostr tags (DM `order_id`, kind-38383 `source`). Never rename one without the other.
+
 **DevFund badge is live-overlaid.** `badges.donatesToDevFund` in `federation.json` is the **static fallback** only. At startup the client probes every coordinator's `GET /api/info/` (`devfund` field, see `services/DevFundProfile.ts`) and, when reachable, overwrites the badge with the coordinator's real `DEVFUND` value before running the devfund-weighted lottery (`utils/federationLottery.ts`). Tor-only/unreachable coordinators (e.g. `clearnet: null` on clearnet web) keep the static value. Keep the static badge reasonably fresh via the coordinator registration template — it is now a fallback, not the source of truth.
 
 ## Traps


### PR DESCRIPTION
## What does this PR do?

Standardize order URL routing across backend (Telegram, Nostr) and frontend (Notifications).

- Implement federation-wide shortAlias resolution based on COORDINATOR_ALIAS env variable, ensuring consistent routing for all coordinators even when deployment aliases (identifier/longAlias) diverge from shortAlias.
- Fix broken Telegram notification URLs (previously 404 on Django backend).
- Fix incomplete/fragile frontend navigation from Nostr notifications, ensuring it resolves the canonical shortAlias before routing.
- Add robust fallback chain for federation document loading (custom path -> bundled fallback).


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.