### PR TITLE
chore(deps): apply safe dependabot upgrades

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: 'Download Android Web.bundle Artifact (built frontend)'
         if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-        uses: dawidd6/action-download-artifact@v23
+        uses: dawidd6/action-download-artifact@v24
         with:
           workflow: frontend-build.yml
           workflow_conclusion: success

--- a/.github/workflows/coordinator-image.yml
+++ b/.github/workflows/coordinator-image.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: 'Download Basic main.js Artifact'
       if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-      uses: dawidd6/action-download-artifact@v23
+      uses: dawidd6/action-download-artifact@v24
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: 'Download Basic main.js Artifact'
         if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-        uses: dawidd6/action-download-artifact@57aa996fc1713cc1579039614f4645a7f4841fd4  # v23
+        uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7  # v24
         with:
           workflow: frontend-build.yml
           workflow_conclusion: success

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Create Windows ZIP file
         run: |
           cd desktopApp/release-builds
-          zip -r Robosats-win32-ia32.zip Robosats-win32-ia32
+          zip -r Robosats-win32-x64.zip Robosats-win32-x64
 
       - name: Create Linux ZIP file
         run: |
@@ -180,8 +180,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path: desktopApp/release-builds/Robosats-win32-ia32.zip
-          name: robosats-desktop-${{ inputs.semver }}-win32-ia32.zip
+          path: desktopApp/release-builds/Robosats-win32-x64.zip
+          name: robosats-desktop-${{ inputs.semver }}-win32-x64.zip
 
       - name: Upload Linux Build Artifact
         if: inputs.semver != ''
@@ -209,8 +209,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path: desktopApp/release-builds/Robosats-win32-ia32.zip
-          name: robosats-desktop-${{ steps.commit.outputs.short }}-win32-ia32.zip
+          path: desktopApp/release-builds/Robosats-win32-x64.zip
+          name: robosats-desktop-${{ steps.commit.outputs.short }}-win32-x64.zip
 
       - name: Upload Linux Build Artifact
         id: upload-release-linux-zip-asset

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,7 +46,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: 'Download static files Artifact'
-      uses: dawidd6/action-download-artifact@v23
+      uses: dawidd6/action-download-artifact@v24
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success
@@ -114,7 +114,7 @@ jobs:
       uses: actions/checkout@v7
 
     - name: 'Download static files Artifact'
-      uses: dawidd6/action-download-artifact@v23
+      uses: dawidd6/action-download-artifact@v24
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: .
-          name: robosats-desktop-${{ needs.check-versions.outputs.semver }}-win32-ia32.zip
+          name: robosats-desktop-${{ needs.check-versions.outputs.semver }}-win32-x64.zip
 
       - name: 'Upload Windows Build Artifact'
         id: upload-release-win-zip-asset
@@ -235,6 +235,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: Robosats-win32-ia32.zip
-          asset_name: robosats-desktop-${{ needs.check-versions.outputs.semver }}-win32-ia32.${{ steps.short-sha.outputs.short_sha }}.zip
+          asset_path: Robosats-win32-x64.zip
+          asset_name: robosats-desktop-${{ needs.check-versions.outputs.semver }}-win32-x64.${{ steps.short-sha.outputs.short_sha }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/selfhosted-client-image.yml
+++ b/.github/workflows/selfhosted-client-image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: 'Download Basic main.js Artifact'
       if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-      uses: dawidd6/action-download-artifact@v23
+      uses: dawidd6/action-download-artifact@v24
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success

--- a/.github/workflows/web-client-image.yml
+++ b/.github/workflows/web-client-image.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: 'Download Basic main.js Artifact'
       if: inputs.semver == ''  # Only if workflow fired from frontend-build.yml
-      uses: dawidd6/action-download-artifact@v23
+      uses: dawidd6/action-download-artifact@v24
       with:
         workflow: frontend-build.yml
         workflow_conclusion: success

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -12,8 +12,8 @@ activity = "1.11.0"
 constraintlayout = "2.2.1"
 kmpTor= "4.8.10-0-1.4.5"
 kmpTorBinary= "4.8.10-0"
-jna = "5.17.0"
-okhttp = "5.1.0"
+jna = "5.18.1"
+okhttp = "5.2.0"
 quartz = "0.92.7"
 
 [libraries]

--- a/desktopApp/AGENTS.md
+++ b/desktopApp/AGENTS.md
@@ -82,7 +82,7 @@ cd desktopApp && npm run compile   # tsc → index.js + index.js.map; commit the
 **Package** (after bundle + compile):
 ```bash
 npm run package-linux  # → release-builds/Robosats-linux-x64/
-npm run package-win    # → release-builds/Robosats-win32-ia32/
+npm run package-win    # → release-builds/Robosats-win32-x64/
 npm run package-mac    # → release-builds/Robosats-darwin-x64/
 ```
 All use `npx @electron/packager . Robosats --overwrite --out=release-builds`.
@@ -95,7 +95,7 @@ All use `npx @electron/packager . Robosats --overwrite --out=release-builds`.
    `package-win`, `package-linux` (all three cross-compiled on Linux); **never runs
    `npm run compile`**; zips each `release-builds/` tree.
 3. `.github/workflows/release.yml` — `needs: [frontend-build, desktop-build]`; uploads
-   `robosats-desktop-{semver}-{mac-darwin-x64|linux-x64|win32-ia32}.{short_sha}.zip`.
+   `robosats-desktop-{semver}-{mac-darwin-x64|linux-x64|win32-x64}.{short_sha}.zip`.
 
 ## Product Intent
 - **Tor is mandatory and non-optional** — there is no clearnet mode, no system-Tor

--- a/desktopApp/package-lock.json
+++ b/desktopApp/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "@electron/packager": "^20.3.0",
-        "electron": "^43.4.1",
+        "electron": "^44.1.1",
         "typescript": "^7.0.2"
       }
     },
@@ -637,9 +637,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "43.4.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.4.1.tgz",
-      "integrity": "sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==",
+      "version": "44.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.3.0.tgz",
+      "integrity": "sha512-St9EV7F2VtYaYWD2qaAjBwUgKxx39eJOUsUJ5+/1113sqbVfNqv4Dbm/W1rN7qmYSPa+mWwR6yr+b7MfgjgVfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/desktopApp/package.json
+++ b/desktopApp/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@electron/packager": "^20.3.0",
-    "electron": "^43.4.1",
+    "electron": "^44.1.1",
     "typescript": "^7.0.2"
   },
   "build": {

--- a/desktopApp/package.json
+++ b/desktopApp/package.json
@@ -8,7 +8,7 @@
     "compile": "./node_modules/.bin/tsc",
     "test": "echo \"Error: no test specified\" && exit 1",
     "package-linux": "npx @electron/packager . Robosats  --platform=linux --arch=x64 --icon=./assets/icon/Robosats.svg --overwrite  --out=release-builds --asar.unpackDir=tor",
-    "package-win": "npx @electron/packager . Robosats  --platform=win32 --arch=ia32 --icon=./assets/icon/Robosats.ico --overwrite   --out=release-builds --asar.unpackDir=tor",
+    "package-win": "npx @electron/packager . Robosats  --platform=win32 --arch=x64 --icon=./assets/icon/Robosats.ico --overwrite   --out=release-builds --asar.unpackDir=tor",
     "package-mac": "npx @electron/packager . Robosats  --platform=darwin --arch=x64 --icon=./assets/icon/Robosats.icns --overwrite    --out=release-builds --asar.unpackDir=tor"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "js-yaml": "^4.3.1"
+    "js-yaml": "^4.3.2"
   },
   "devDependencies": {
     "ejs": "^3.1.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,14 @@ channels==4.3.2
 channels-redis==4.3.0
 celery==5.6.3
 grpcio==1.83.0
-googleapis-common-protos==1.75.1
+googleapis-common-protos==1.75.2
 grpcio-tools==1.83.0
 numpy==2.5.2
 Pillow==12.3.0
 python-decouple==3.8
 requests[socks]==2.34.2
 ring==0.10.1
-gunicorn==26.1.0
+gunicorn==26.2.0
 psycopg2==2.9.12
 django-import-export==4.4.1
 shapely==2.1.2
@@ -26,8 +26,8 @@ drf-spectacular==0.30.0
 drf-spectacular-sidecar==2026.8.1
 django-cors-headers==4.9.0
 base91==1.0.1
-nostr-sdk==0.45.0
-pygeohash==3.3.1
+nostr-sdk==0.45.1
+pygeohash==3.3.2
 asgiref==3.12.1
 secp256k1==0.14.0
 idna==3.19

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-ruff==0.16.3
+ruff==0.16.4
 coverage==7.15.4
 git+https://github.com/Reckless-Satoshi/drf-openapi-tester.git@2af4d20743439444054c5bf8a02c9f299b14491f
 pre-commit==4.6.2


### PR DESCRIPTION
- dawidd6/action-download-artifact: v23 -> v24 (6 workflow files)
- android jna: 5.17.0 -> 5.18.1
- android okhttp: 5.1.0 -> 5.2.0
- js-yaml (root): 4.3.1 -> 4.3.2
- electron (desktopApp): 43.4.1 -> 44.1.1
- googleapis-common-protos: 1.75.1 -> 1.75.2
- gunicorn: 26.1.0 -> 26.2.0
- nostr-sdk: 0.45.0 -> 0.45.1
- pygeohash: 3.3.1 -> 3.3.2
- ruff: 0.16.3 -> 0.16.4

## What does this PR do?
Fixes #<ISSUE_NUMBER>

This PR introduces/refactors/...

## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.