### PR TITLE
Fix incomplete admin order cancel

### DIFF
--- a/api/admin.py
+++ b/api/admin.py
@@ -55,8 +55,20 @@ class ETokenAdmin(AdminChangeLinksMixin, TokenAdmin):
 class LNPaymentInline(admin.StackedInline):
     model = LNPayment
     can_delete = True
-    fields = ("payment_hash", "num_satoshis", "status", "routing_budget_sats", "description")
-    readonly_fields = ("payment_hash", "num_satoshis", "status", "routing_budget_sats", "description")
+    fields = (
+        "payment_hash",
+        "num_satoshis",
+        "status",
+        "routing_budget_sats",
+        "description",
+    )
+    readonly_fields = (
+        "payment_hash",
+        "num_satoshis",
+        "status",
+        "routing_budget_sats",
+        "description",
+    )
     show_change_link = True
     show_full_result_count = True
     extra = 0
@@ -157,15 +169,26 @@ class OrderAdmin(AdminChangeLinksMixin, admin.ModelAdmin):
         """
         for order in queryset:
             if order.status in [Order.Status.PUB, Order.Status.PAU]:
-                if Logics.return_bond(order.maker_bond):
-                    order.update_status(Order.Status.UCA)
+                try:
+                    success, _ = Logics.close_public_order(
+                        order,
+                        actor="coordinator",
+                        notification_message="coordinator_cancelled",
+                    )
+                except Exception as e:
+                    success = False
+                    self.message_user(
+                        request,
+                        f"Could not close {order.id}: {e}",
+                        messages.ERROR,
+                    )
+                    continue
+
+                if success:
                     self.message_user(
                         request,
                         f"Order {order.id} successfully closed",
                         messages.SUCCESS,
-                    )
-                    send_notification.delay(
-                        order_id=order.id, message="coordinator_cancelled"
                     )
                 else:
                     self.message_user(

--- a/api/logics.py
+++ b/api/logics.py
@@ -323,6 +323,8 @@ class Logics:
 
             send_notification.delay(order_id=order.id, message="order_expired_untaken")
 
+            nostr_send_order_event.delay(order_id=order.id)
+
             order.log("Order expired while public or paused")
             order.log("Maker bond was <b>unlocked</b>")
 
@@ -1011,6 +1013,48 @@ class Logics:
         return False, None
 
     @classmethod
+    def close_public_order(
+        cls, order, actor="maker", notification_message="public_order_cancelled"
+    ):
+        """Closes a Public/Paused order: unlocks the maker bond, expires
+        every pending pretaker bond, notifies and republishes the Nostr
+        event. Shared by the maker's own cancel flow and the coordinator's
+        admin action."""
+
+        # Return the maker bond. If this fails, the order is left untouched.
+        if not cls.return_bond(order.maker_bond):
+            return False, None
+
+        # Atomically flip PUB/PAU -> UCA. If the status is no longer
+        # PUB/PAU (e.g. a taker locked the bond concurrently and the
+        # contract was formalized), do not clobber the live contract.
+        if not order.transition_status(
+            Order.Status.UCA,
+            from_statuses=[Order.Status.PUB, Order.Status.PAU],
+        ):
+            return False, None
+
+        order.log(f"Order cancelled by {actor} while public or paused")
+        order.log("Maker bond was <b>unlocked</b>")
+
+        take_orders_queryset = TakeOrder.objects.filter(order=order)
+        for idx, take_order in enumerate(take_orders_queryset):
+            order.log("Pretaker bond was <b>unlocked</b>")
+            try:
+                cls.take_order_expires(take_order)
+            except Exception as e:
+                order.log(
+                    f"Failed to expire TakeOrder({take_order.id}): {e}",
+                    level="ERROR",
+                )
+
+        send_notification.delay(order_id=order.id, message=notification_message)
+
+        nostr_send_order_event.delay(order_id=order.id)
+
+        return True, None
+
+    @classmethod
     def cancel_order(cls, order, user, cancel_status=None):
         # If cancel status is specified, do no cancel the order
         # if it is not the correct one.
@@ -1061,23 +1105,11 @@ class Logics:
                 # to prevent DDOS on the LN node and order book. If not strict, maker is returned
                 # the bond (more user friendly).
                 # Return the maker bond (Maker gets returned the bond for cancelling public order)
-                if cls.return_bond(order.maker_bond):
-                    order.update_status(Order.Status.UCA)
-
-                    order.log("Order cancelled by maker while public or paused")
-                    order.log("Maker bond was <b>unlocked</b>")
-
-                    take_orders_queryset = TakeOrder.objects.filter(order=order)
-                    for idx, take_order in enumerate(take_orders_queryset):
-                        order.log("Pretaker bond was <b>unlocked</b>")
-                        cls.take_order_expires(take_order)
-
-                    send_notification.delay(
-                        order_id=order.id, message="public_order_cancelled"
-                    )
-                    nostr_send_order_event.delay(order_id=order.id)
-
+                valid, _ = cls.close_public_order(order)
+                if valid:
                     return True, None
+                # Fall through to the generic error, as when the
+                # bond could not be unlocked before the refactor.
             else:
                 # 2.b) When pretaker cancels before bond
                 # LNPayment "take_order" is expired

--- a/tests/test_trade_pipeline.py
+++ b/tests/test_trade_pipeline.py
@@ -6,10 +6,12 @@ from decouple import config
 from django.contrib.auth.models import User
 from django.urls import reverse
 
-from api.models import Currency, Order
-from api.tasks import cache_market
+from api.models import Currency, LNPayment, Order, TakeOrder
+from api.tasks import cache_market, send_notification
 from django.utils import timezone
 from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
 from control.models import BalanceLog
 from control.tasks import compute_node_balance, do_accounting
 from tests.test_api import BaseAPITestCase
@@ -1389,6 +1391,100 @@ class TradeTest(BaseAPITestCase):
         data = trade.response.json()
         self.assertEqual(data["error_code"], 1043)
         self.assertEqual(data["bad_request"], "This order has been cancelled")
+
+    @patch("api.logics.nostr_send_order_event")
+    @patch("api.tasks.send_notification.delay", send_notification)
+    def test_admin_cancel_public_order(self, nostr_mock):
+        """
+        Tests the coordinator's admin action that closes a public order
+        with a pending pretaker. The pretaker bond must be unlocked, the
+        maker bond returned, the maker notified and the Nostr event
+        republished.
+        """
+        trade = Trade(self.client)
+        trade.publish_order()
+        trade.take_order()
+        # Pretaker fetches the order: generates the taker bond hold invoice
+        trade.get_order(trade.taker_index)
+
+        order = Order.objects.get(id=trade.order_id)
+        take_order = TakeOrder.objects.get(order=order)
+        self.assertIsNotNone(take_order.taker_bond)
+        self.assertEqual(take_order.taker_bond.status, LNPayment.Status.INVGEN)
+
+        nostr_mock.reset_mock()
+
+        # Coordinator closes the public order from the admin
+        request = RequestFactory().post("/")
+        request.session = "session"
+        setattr(request, "_messages", FallbackStorage(request))
+        order_admin = OrderAdmin(model=Order, admin_site=AdminSite())
+        order_admin.cancel_public_order(
+            request, Order.objects.filter(id=trade.order_id)
+        )
+
+        order = Order.objects.get(id=trade.order_id)
+        self.assertEqual(order.status, Order.Status.UCA)
+        self.assertEqual(order.maker_bond.status, LNPayment.Status.RETNED)
+
+        take_order.refresh_from_db()
+        self.assertEqual(take_order.taker_bond.status, LNPayment.Status.CANCEL)
+
+        nostr_mock.delay.assert_called_once_with(order_id=trade.order_id)
+
+        maker_headers = trade.get_robot_auth(trade.maker_index)
+        response = self.client.get(reverse("notifications"), **maker_headers)
+        self.assertResponse(response)
+        notifications_data = list(response.json())
+        self.assertTrue(
+            any(
+                notification["order_id"] == trade.order_id
+                and "has been cancelled by the coordinator" in notification["title"]
+                for notification in notifications_data
+            ),
+            "Maker was not notified about the coordinator cancellation",
+        )
+
+    def test_admin_cancel_non_public_order(self):
+        """
+        The admin action must not touch orders that are not Public/Paused.
+        """
+        trade = Trade(self.client)
+        trade.publish_order()
+        trade.take_order()
+        trade.lock_taker_bond()  # Order is now WF2
+
+        request = RequestFactory().post("/")
+        request.session = "session"
+        setattr(request, "_messages", FallbackStorage(request))
+        order_admin = OrderAdmin(model=Order, admin_site=AdminSite())
+        order_admin.cancel_public_order(
+            request, Order.objects.filter(id=trade.order_id)
+        )
+
+        order = Order.objects.get(id=trade.order_id)
+        self.assertEqual(order.status, Order.Status.WF2)
+        self.assertEqual(order.maker_bond.status, LNPayment.Status.LOCKED)
+
+    @patch("api.logics.nostr_send_order_event")
+    def test_expired_public_order_nostr_event(self, nostr_mock):
+        """
+        An untaken public order that expires must republish its Nostr
+        event so that federation clients drop it from the live order book.
+        """
+        trade = Trade(self.client)
+        trade.publish_order()
+        trade.take_order()
+        nostr_mock.reset_mock()
+
+        trade.expire_order()
+        trade.clean_orders()
+
+        order = Order.objects.get(id=trade.order_id)
+        self.assertEqual(order.status, Order.Status.EXP)
+        self.assertEqual(order.expiry_reason, Order.ExpiryReasons.NTAKEN)
+
+        nostr_mock.delay.assert_called_once_with(order_id=trade.order_id)
 
     def test_cancel_order_cancel_status(self):
         """


### PR DESCRIPTION
## What does this PR do?

The `cancel_public_order` admin action was leaving the system in an inconsistent state by failing to expire pending pretaker bonds, missing audit logs, and omitting the required Nostr order book synchronization. This change introduces `Logics.close_public_order` to centralize the cancellation logic (previously duplicated in `cancel_order` and `order_expires`), ensures atomic state transitions, proper TakeOrder cleanup, and robust event notification, aligning admin-initiated cancels with the standard user cancellation flow.


## Checklist before merging
- [x] Install [pre-commit](https://pre-commit.com/#installation) and initialize it: `pip install pre-commit`, then `pre-commit install`. Pre-commit installs git hooks that automatically check the codebase. If pre-commit fails when you commit your changes, please fix the problems it points out.